### PR TITLE
Review: Blesta SDK hardening sprint (#34)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,23 @@
+# Blesta SDK — environment configuration example
+# Copy this file to .env and fill in real values.
+# Never commit .env to version control.
+
+# --- Dev environment ---
+BLESTA_DEV_URL=https://dev.your-blesta-domain.com/api
+BLESTA_DEV_USER=your_dev_api_user
+BLESTA_DEV_KEY=your_dev_api_key
+
+# --- Stage environment ---
+BLESTA_STAGE_URL=https://stage.your-blesta-domain.com/api
+BLESTA_STAGE_USER=your_stage_api_user
+BLESTA_STAGE_KEY=your_stage_api_key
+
+# --- Live (production) environment ---
+BLESTA_LIVE_URL=https://your-blesta-domain.com/api
+BLESTA_LIVE_USER=your_live_api_user
+BLESTA_LIVE_KEY=your_live_api_key
+
+# --- Legacy single-environment CLI variables (still supported by the CLI) ---
+# BLESTA_API_URL=https://your-blesta-domain.com/api
+# BLESTA_API_USER=your_api_user
+# BLESTA_API_KEY=your_api_key

--- a/.github/workflows/schema-refresh.yml
+++ b/.github/workflows/schema-refresh.yml
@@ -1,0 +1,50 @@
+name: Schema Refresh
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'  # weekly, Monday at 06:00 UTC
+  workflow_dispatch:       # allow manual trigger
+
+jobs:
+  refresh-schemas:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        run: pip install uv
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Run core schema extractor
+        run: uv run python tools/extract_schema.py
+
+      - name: Run plugin schema extractor
+        run: uv run python tools/extract_plugin_schema.py
+
+      - name: Open PR if schemas changed
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore(schemas): automated weekly refresh"
+          title: "chore(schemas): automated weekly schema refresh"
+          body: |
+            Automated schema refresh triggered by the weekly schedule.
+
+            Both extraction tools were run against the live Blesta documentation.
+            Review the diff to confirm the changes are expected before merging.
+
+            > ⚠️ Do **not** merge if credentials or personal data appear in the diff.
+          branch: chore/schema-refresh-auto
+          base: master
+          delete-branch: true
+          labels: schemas,automated

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,8 +34,9 @@ uv build                                   # Build package
 - `src/blesta_sdk/_validation.py` — shared URL segment validation (used by both sync and async clients)
 - `src/blesta_sdk/_dateutil.py` — internal date range utilities for time-series reports
 - `src/blesta_sdk/_cli.py` — CLI entry point (registered as `blesta` in pyproject.toml)
-- `schemas/` — bundled JSON schemas (core: 63 models, plugin: 8 models) used by `BlestaDiscovery`
-- `tools/` — schema extraction utilities (`extract_schema.py`, `extract_plugin_schema.py`, `_classify.py`)
+- `src/blesta_sdk/schemas/` — **canonical** bundled JSON schemas (core: 63 models, plugin: 8 models) used by `BlestaDiscovery`. This is the single source of truth. Do not edit the root `schemas/` copies.
+- `tools/` — schema extraction utilities (`extract_schema.py`, `extract_plugin_schema.py`, `_classify.py`). Both tools write to `src/blesta_sdk/schemas/` by default.
+- `schemas/` — **deprecated** root-level copy; will be removed once stale copies are cleaned up
 - `tests/` — unit tests (mocked) + one live integration test (`test_credentials`)
 - `benchmarks/` — performance benchmarks (pytest-benchmark, not collected in CI)
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,0 +1,143 @@
+# Migration Idempotency Design
+
+This document describes the agreed strategy for migrating data between Blesta
+instances (or from external billing platforms) without duplicating financial
+records.
+
+---
+
+## Core Principle
+
+**Every migration must be safe to restart.**
+
+A partially completed migration — interrupted by a crash, network error, or
+operator stop — must be resumable from any point without creating duplicate
+clients, invoices, services, transactions, or payment accounts.
+
+---
+
+## Strategy: Migration Ledger + Check-Then-Create + Source IDs
+
+### 1. Migration Ledger
+
+Maintain an external table (database, CSV, or JSON file) that maps source IDs
+to target IDs:
+
+| Column | Description |
+|--------|-------------|
+| `source_blesta_client_id` | Client ID in the source system |
+| `target_blesta_client_id` | Client ID created in the target Blesta |
+| `source_invoice_id` | Invoice ID in the source system |
+| `target_invoice_id` | Invoice ID created in the target Blesta |
+| `source_service_id` | Service ID in the source system |
+| `target_service_id` | Service ID created in the target Blesta |
+| `source_transaction_id` | Transaction ID in the source system |
+| `target_transaction_id` | Transaction ID created in the target Blesta |
+| `migrated_at` | Timestamp when the record was created in the target |
+
+Before creating any record, **check the ledger first**. If a mapping already
+exists, skip creation and use the existing target ID.
+
+### 2. Check-Then-Create
+
+Before calling any POST endpoint that creates a record, query the target system
+to confirm the record does not already exist:
+
+```python
+# Example: migrate a client
+def migrate_client(source_client, ledger, api):
+    # 1. Check ledger first
+    if ledger.has_client(source_client["id"]):
+        target_id = ledger.get_client(source_client["id"])
+        return target_id  # already migrated
+
+    # 2. Search by source_id custom field
+    existing = api.get("clients", "getList", {
+        "custom_fields[source_id]": source_client["id"]
+    })
+    if existing.data:
+        target_id = existing.data[0]["id"]
+        ledger.record_client(source_client["id"], target_id)
+        return target_id
+
+    # 3. Create the client
+    response = api.post("clients", "create", {
+        **source_client,
+        "custom_fields[source_id]": source_client["id"],
+    })
+    target_id = response.data["id"]
+    ledger.record_client(source_client["id"], target_id)
+    return target_id
+```
+
+### 3. Source IDs via Custom Fields
+
+Pass `source_id` (or an `external_ref`) in Blesta `custom_fields` when
+creating records. This allows idempotent lookup even if the migration ledger
+is lost:
+
+```python
+api.post("clients", "create", {
+    "first_name": "Alice",
+    "custom_fields[source_id]": "prime_12345",
+})
+```
+
+Always query by `custom_fields[source_id]` before creating, so re-running the
+migration script skips already-migrated records.
+
+---
+
+## Entity Migration Order
+
+Respect referential integrity by migrating in this order:
+
+1. **Clients** — no dependencies
+2. **Contacts** — depends on clients
+3. **Services** — depends on clients and packages
+4. **Invoices** — depends on clients
+5. **Invoice Line Items** — depends on invoices
+6. **Transactions** — depends on clients and invoices
+7. **Payment Accounts** — depends on clients
+
+---
+
+## What NOT to Do
+
+- **Do not use `retry_mutations=True` as an idempotency mechanism.**
+  A 5xx response after a POST does not mean the record was not created.
+  Retrying will create duplicates. The SDK does not retry mutations on 5xx
+  for exactly this reason.
+
+- **Do not assume a failed POST means no record was created.**
+  Network timeouts and server errors can occur after Blesta processes the
+  write. Always check-then-create on restart.
+
+- **Do not run migration scripts in parallel against the same entity type**
+  unless you have a distributed lock or partition the records by range.
+
+---
+
+## Restartability Checklist
+
+- [ ] Migration ledger is persisted externally (not in-memory).
+- [ ] Every entity is checked against the ledger before creation.
+- [ ] Custom `source_id` field is set on every created record.
+- [ ] The script can be killed and restarted at any point.
+- [ ] Running the script twice produces the same result (idempotent).
+- [ ] No financial records (invoices, transactions) are created twice.
+
+---
+
+## SDK Usage Note
+
+When migrating, prefer:
+
+```python
+api = BlestaRequest(url, user, key, raise_on_error=True)
+```
+
+This surfaces Blesta validation errors immediately rather than returning
+HTTP 200 responses that contain `{"errors": {...}}` in the body.
+
+See also: [SDK_USAGE.md](../SDK_USAGE.md)

--- a/docs/reviews/hardening-sprint-final-report.md
+++ b/docs/reviews/hardening-sprint-final-report.md
@@ -1,0 +1,278 @@
+# Blesta SDK Hardening Sprint — Final Report
+
+**Date:** 2026-05-27  
+**Author:** jwogrady  
+**Repo:** https://github.com/jwogrady/blesta_sdk  
+**Review range:** `5fa6262..c7faadf`  
+**Base (pre-sprint):** `5fa6262` — docs: add 2026-05-27 code review (16 findings, 8 test gaps)  
+**Head (post-sprint):** `c7faadf` — merge: hardening sprint complete (lanes 1-11, #8–#14, #16–#23, #32–#33)
+
+---
+
+## Test Results
+
+| Command | Result |
+|---------|--------|
+| `uv run pytest -q -m "not integration"` | **730 passed**, 1 deselected (integration), 0 failures |
+| `uv run pytest --cov=blesta_sdk --cov-fail-under=97` | **97.04%** — threshold met |
+| `uv run black --check src/ tests/ tools/` | ✅ 25 files unchanged |
+| `uv run ruff check src/ tests/ tools/` | ✅ All checks passed |
+
+---
+
+## Issues Addressed
+
+### Lane 1 — Response correctness
+
+**#8 [HIGH]** HTTP 200 validation failures invisible  
+**#24 [TEST]** Missing: HTTP 200 with `{"errors":{}}` body treated as success
+
+- `BlestaResponse.errors()` now detects Blesta's plural `"errors"` key in HTTP 200 bodies.
+- `raise_for_status()` raises `BlestaAPIError` when HTTP 200 carries validation errors.
+- Commit: `9369168`
+
+---
+
+### Lane 2 — Pagination integrity
+
+**#10 [HIGH]** Falsy-zero terminates pagination early  
+**#17 [MEDIUM]** Alternating bad pages escape stuck-page detector
+
+- `PaginationState.check_data()` changed from `if not data` to
+  `if data is None or data == [] or data == {}` — preserves `0`, `False`, `""`.
+- Added a 6-slot rolling window of page-content hashes; raises `PaginationError`
+  when the window contains exactly 2 unique hashes in alternating order (A→B→A→B).
+- Commit: `5097a5a`
+
+---
+
+### Lane 3 — HTTP + path validation hardening
+
+**#11 [HIGH]** Credentials sent over plaintext HTTP with no warning  
+**#16 [MEDIUM]** `validate_segment()` doesn't block percent-encoded path traversal
+
+- Both `BlestaRequest` and `AsyncBlestaRequest` raise `ValueError` on `http://` URLs
+  unless `allow_http=True` is passed explicitly to the constructor.
+- `validate_segment()` now rejects any segment containing `%`, blocking `%2F`,
+  `%2e%2e`, `%00`, and all other percent-encoded bypasses.
+- Commit: `b561201`
+
+---
+
+### Lane 4 — Retry semantics / billing safety
+
+**#12 [HIGH]** `retry_mutations=True` can duplicate billing writes on 5xx
+
+- POST and PUT requests now only retry on HTTP 429 (rate-limit), never on 5xx.
+- A server error does not guarantee the write failed; retrying risks duplicate records.
+- GET/DELETE continue to retry on both 5xx and 429.
+- Commit: `37e012a`
+
+---
+
+### Lane 5 — Discovery runtime safety
+
+**#9 [HIGH]** `assert` guards in `BlestaDiscovery` silently removed under `python -O`
+
+- All 14 `assert` statements in `_discovery.py` replaced with explicit
+  `if ... raise RuntimeError(...)` checks that survive the optimizer.
+- Commit: `bb5f5d7`
+
+---
+
+### Lane 6 — Async concurrency
+
+**#13 [MEDIUM]** `get_all_fast` fallback to `get_all` bypasses semaphore  
+**#15 [MEDIUM]** `extract` holds semaphore for entire multi-page fetch
+
+- `get_all_fast()` fallback path now wrapped in `async with self._semaphore:`.
+- `extract()` gates each individual page request inside the semaphore via an
+  inline pagination loop (one acquire/release per request, not per model).
+- Commit: `5bc10f7`
+
+---
+
+### Lane 7 — CLI last_request redaction
+
+**#19 [MEDIUM]** `_last_request` stores args by mutable reference — CLI prints sensitive params
+
+- `submit()` now stores `args.copy()` in `_last_request`, preventing mutation of
+  the stored record after the call.
+- `get_last_request()` returns a redacted view via `_redact_args()`, replacing the
+  values of sensitive keys with `"***"`.
+- Redacted keys (case-insensitive): `api_key`, `password`, `pass`, `secret`,
+  `token`, `auth`, `authorization`, `card_number`, `cvv`, `cvc`, `ssn`,
+  `bank_account`, `routing_number`.
+- Commit: `5bc10f7`
+
+---
+
+### Lane 8 — API semantics cleanup
+
+**#18 [MEDIUM]** `call_all()` claims schema inference but unconditionally calls `get_all()`  
+**#20 [MEDIUM]** `call()` silently falls back to POST for unknown methods  
+**#21 [LOW]** `count_for()` fallback fires unvalidated `list_method+Count` endpoint  
+**#22 [LOW]** `format` parameter in `generate_capabilities_report` shadows built-in  
+**#23 [LOW]** `BlestaDiscovery` global singleton ignores custom schema paths from caller
+
+- `call()` raises `ValueError` when neither schema nor prefix heuristics resolve the method.
+- `call_all()` looks up the method in the schema and raises `ValueError` if it resolves
+  to a non-GET verb before paginating.
+- `count_for()` emits `logger.warning()` when falling back to `list_method + "Count"`.
+- `generate_capabilities_report()` parameter renamed `format` → `output_format`.
+- Both clients accept `discovery=` constructor argument; `_get_discovery()` returns
+  the injected instance directly, bypassing the module singleton.
+- Commit: `5bc10f7` / `bb5f5d7`
+
+---
+
+### Lane 7–8 Test Gaps (issues #25–#31)
+
+**#25** Non-integer Retry-After (float / HTTP-date) — `test_retry_after_float_header`, `test_retry_after_http_date_header`  
+**#26** `iter_all` `on_error=raise` with page-1 failure — `test_iter_all_on_error_raise_page1_failure`  
+**#27** SSL error path — `test_ssl_error_returns_blesta_response`  
+**#28** Async header auth `client.auth is None` — `test_async_header_auth_sets_auth_none`  
+**#29** `to_dataframe()` after `free_raw()` — `test_to_dataframe_after_free_raw`  
+**#30** Successful first POST must not retry — `test_retry_mutations_successful_first_post_returns_immediately`  
+**#31** `get_all_fast(verify=True)` count mismatch — `test_get_all_fast_verify_count_mismatch_logs_warning`
+
+All committed in: `5bc10f7`
+
+---
+
+### Lane 9 — Schema refresh workflow
+
+**#32 [MEDIUM]** No automated schema refresh in CI
+
+- Added `.github/workflows/schema-refresh.yml`: weekly Monday 06:00 UTC +
+  `workflow_dispatch` trigger.
+- Runs both `extract_schema.py` and `extract_plugin_schema.py`.
+- Opens a PR via `peter-evans/create-pull-request@v6` when any schema file changes.
+- Updated `DEFAULT_OUTPUT` in both tools to write to `src/blesta_sdk/schemas/`
+  (the canonical bundled location) rather than the deprecated root `schemas/`.
+- Commit: `6aa69a6`
+
+---
+
+### Lane 10 — Migration idempotency design
+
+**#33 [MEDIUM]** No idempotency mechanism for billing POST mutations
+
+- Added `docs/migration.md` documenting the ledger + check-then-create + source-ID
+  pattern for safe, restartable migrations.
+- Covers entity migration order: clients → contacts → services → invoices →
+  transactions → payment accounts.
+- Explicitly states `retry_mutations=True` **must not** be used as an idempotency
+  mechanism (it only retries 429s, does not prevent duplicate writes on 5xx).
+- Commit: `1973891`
+
+---
+
+### Lane 11 — Dev/stage/live environment config
+
+**#14** Add support for dev, stage, and live environment configuration
+
+- Added `BlestaEnvConfig` (exported from `blesta_sdk.__all__`).
+- Accepts `env="dev"|"stage"|"live"` and resolves credentials from:
+  1. Explicit constructor kwargs (`url=`, `user=`, `key=`)
+  2. Environment variables `BLESTA_{ENV}_URL`, `BLESTA_{ENV}_USER`, `BLESTA_{ENV}_KEY`
+- Never falls back between environments (stage credentials are never used for live).
+- `cfg.client(**kwargs)` returns a configured `BlestaRequest`.
+- Added `.env.example` with placeholder-only values.
+- 17 tests in `tests/test_env_config.py`.
+- Commits: `2d4ad44`, `8315a49`
+
+---
+
+## Breaking Changes
+
+1. **`call()` raises `ValueError`** for methods that cannot be resolved to an HTTP verb.
+   Previously silently fell back to POST. Callers that relied on the fallback must either
+   pass `action=` explicitly or use schema-resolvable method names.
+
+2. **`http://` URLs raise `ValueError`** by default in both sync and async clients.
+   Existing `BlestaRequest("http://...")` calls must add `allow_http=True` to opt in.
+
+3. **POST/PUT no longer retry on 5xx** even when `retry_mutations=True`.
+   Only HTTP 429 triggers a retry for mutations. This is intentional and correct — a
+   5xx does not guarantee the write failed.
+
+4. **`generate_capabilities_report(format=...)` → `output_format=`**.
+   Any caller using the keyword argument `format=` must rename it `output_format=`.
+
+---
+
+## Known Risks / Deferred Items
+
+- **`_discovery.py` RuntimeError guards (13 lines, 93% branch coverage)**: The guards
+  protecting against `_registry is None` after `_ensure_loaded()` are practical
+  dead code in normal operation. Tests exist for the primary paths; triggering these
+  specific guards requires direct object manipulation. Left as-is; they are defensive
+  checks, not behavior paths.
+
+- **`__init__.py` ImportError path for `AsyncBlestaRequest` (lines 39–40)**: Triggered
+  only when `httpx` is not installed. Not covered in CI (httpx is always present in the
+  dev environment). Acceptable coverage gap.
+
+- **`_pagination.py` hash-exception path (lines 122–123)**: Triggered only when
+  `hash(str(data))` raises, which is not possible with standard Python types. Defensive
+  code; left uncovered.
+
+- **`_response.py` line 240** (`CSV + non-200`): `is_csv` returns `False` for non-200
+  responses, making the inner `status_code != 200` branch in `errors()` unreachable
+  through normal construction. Logically dead; acceptable.
+
+- **Schema refresh CI** (#32): The `peter-evans/create-pull-request@v6` action requires
+  a valid `GITHUB_TOKEN` or PAT with PR write permission. Has not been exercised against
+  the live repo yet.
+
+---
+
+## Commit Range
+
+```
+5fa6262..c7faadf
+```
+
+```
+5fa6262  docs: add 2026-05-27 code review (16 findings, 8 test gaps)   ← BASE (pre-sprint)
+875e82a  fix(response): surface Blesta 200 validation errors (#8, #24)
+f77af7d  fix(pagination): preserve falsy scalar payloads, detect alternating loops (#10, #17)
+9369168  fix(response): surface Blesta 200 validation errors (#8, #24)  [merge]
+5097a5a  fix(pagination): preserve falsy scalar payloads, detect alternating loops (#10, #17)
+b561201  fix(client): require explicit HTTP opt-in, block percent-encoded paths (#11, #16)
+37e012a  fix(client): don't retry mutations on 5xx, only 429 (#12)
+bb5f5d7  fix(discovery): replace assert guards with RuntimeError, rename format param (#9, #22, #23)
+fd97f31  merge: lanes 3-5 + API semantics cleanup (#9, #11, #12, #16, #22, #23)  [merge]
+5bc10f7  fix(client): API semantics, last_request redaction/copy, async semaphore (#13, #15, #18, #19, #20, #21)
+6aa69a6  fix(schemas): point extraction tools at canonical path, add weekly refresh CI workflow (#32)
+1973891  docs(migration): add idempotency design — ledger + check-then-create + source IDs (#33)
+2d4ad44  feat(config): add BlestaEnvConfig for dev/stage/live environment selection (#14)
+8315a49  tests: add coverage gap tests, mark unreachable retry return pragma no cover
+c7faadf  merge: hardening sprint complete (lanes 1-11, #8–#14, #16–#23, #32–#33)  ← HEAD
+```
+
+---
+
+## Files Changed (summary)
+
+| File | Change |
+|------|--------|
+| `src/blesta_sdk/_response.py` | Detect plural `errors` key; `raise_for_status` on 200+errors |
+| `src/blesta_sdk/_pagination.py` | Falsy-zero fix; alternating-page window detection |
+| `src/blesta_sdk/_validation.py` | Block `%`-encoded segments |
+| `src/blesta_sdk/_client.py` | `allow_http`, percent-encoding, mutation retry, `call()`/`call_all()`/`count_for()` semantics, `_last_request` redaction, injectable `discovery=` |
+| `src/blesta_sdk/_async_client.py` | Mirror of sync client fixes; semaphore gating for `get_all_fast` and `extract` |
+| `src/blesta_sdk/_discovery.py` | Replace `assert` → `RuntimeError`; rename `format` → `output_format` |
+| `src/blesta_sdk/_env_config.py` | **New**: `BlestaEnvConfig` |
+| `src/blesta_sdk/__init__.py` | Export `BlestaEnvConfig` |
+| `.env.example` | **New**: placeholder-only credentials template |
+| `.github/workflows/schema-refresh.yml` | **New**: weekly schema refresh CI |
+| `docs/migration.md` | **New**: migration idempotency design |
+| `docs/reviews/hardening-sprint-final-report.md` | **New**: this file |
+| `CLAUDE.md` | Note canonical schema location |
+| `tools/extract_schema.py` | Write to `src/blesta_sdk/schemas/` |
+| `tools/extract_plugin_schema.py` | Write to `src/blesta_sdk/schemas/` |
+| `tests/test_blesta_sdk.py` | +~280 lines of new/updated tests |
+| `tests/test_async_client.py` | +~103 lines of new tests |
+| `tests/test_env_config.py` | **New**: 17 tests for `BlestaEnvConfig` |

--- a/src/blesta_sdk/__init__.py
+++ b/src/blesta_sdk/__init__.py
@@ -2,6 +2,7 @@
 
 from ._client import BlestaRequest
 from ._discovery import BlestaDiscovery, MethodSpec
+from ._env_config import BlestaEnvConfig
 from ._exceptions import (
     BlestaAPIError,
     BlestaAuthError,
@@ -19,6 +20,7 @@ __all__ = [
     "BlestaAuthError",
     "BlestaConnectionError",
     "BlestaDiscovery",
+    "BlestaEnvConfig",
     "BlestaError",
     "BlestaRateLimitError",
     "BlestaRequest",

--- a/src/blesta_sdk/_async_client.py
+++ b/src/blesta_sdk/_async_client.py
@@ -17,6 +17,7 @@ from typing import Any, Literal
 
 import httpx
 
+from blesta_sdk._client import _redact_args
 from blesta_sdk._dateutil import _month_boundaries
 from blesta_sdk._pagination import PaginationState
 from blesta_sdk._response import BlestaResponse
@@ -73,6 +74,13 @@ class AsyncBlestaRequest:
         :meth:`~blesta_sdk.BlestaResponse.raise_for_status` before
         returning, raising a :class:`~blesta_sdk.BlestaError` subclass
         on non-success responses. Defaults to ``False``.
+    :param allow_http: When ``True``, permits ``http://`` base URLs.
+        Defaults to ``False``. HTTP sends credentials in plaintext —
+        only enable this for local development or explicit test
+        environments.
+    :param discovery: Optional :class:`~blesta_sdk.BlestaDiscovery` instance
+        to use instead of the module-level singleton. Useful when loading
+        schemas from a custom path or when injecting a mock in tests.
     """
 
     def __init__(
@@ -88,7 +96,14 @@ class AsyncBlestaRequest:
         max_concurrency: int = 10,
         auth_method: Literal["basic", "header"] = "basic",
         raise_on_error: bool = False,
+        allow_http: bool = False,
+        discovery: Any = None,
     ):
+        if url.startswith("http://") and not allow_http:
+            raise ValueError(
+                "base_url uses HTTP which sends credentials in plaintext. "
+                "Pass allow_http=True to explicitly permit this (local/dev only)."
+            )
         self.base_url = url.rstrip("/") + "/"
         self.user = user
         self.key = key
@@ -97,6 +112,7 @@ class AsyncBlestaRequest:
         self.retry_mutations = retry_mutations
         self.auth_method = auth_method
         self.raise_on_error = raise_on_error
+        self._discovery = discovery
         self._last_request: dict[str, Any] | None = None
         self._semaphore = asyncio.Semaphore(max_concurrency)
         auth = None if auth_method == "header" else httpx.BasicAuth(self.user, self.key)
@@ -133,9 +149,14 @@ class AsyncBlestaRequest:
     def _validate_segment(segment: str, name: str) -> None:
         validate_segment(segment, name)
 
-    @staticmethod
-    def _get_discovery() -> Any:
-        """Return the module-level cached BlestaDiscovery singleton."""
+    def _get_discovery(self) -> Any:
+        """Return the BlestaDiscovery instance for this client.
+
+        Returns the instance passed at construction time if provided,
+        otherwise falls back to the module-level singleton.
+        """
+        if self._discovery is not None:
+            return self._discovery
         from blesta_sdk._discovery import _get_discovery
 
         return _get_discovery()
@@ -221,7 +242,7 @@ class AsyncBlestaRequest:
         self._validate_segment(model, "model")
         self._validate_segment(method, "method")
         url = f"{self.base_url}{model}/{method}.json"
-        request_info = {"url": url, "args": args}
+        request_info = {"url": url, "args": args.copy()}
         self._last_request = request_info
         _last_request_var.set(request_info)
 
@@ -246,9 +267,18 @@ class AsyncBlestaRequest:
                     response.text, response.status_code, response.headers
                 )
 
-                is_retriable = (
-                    response.status_code >= 500 or response.status_code == 429
-                )
+                # Mutations (POST/PUT) must never be retried on 5xx — a server
+                # error does not guarantee the write failed, and retrying risks
+                # duplicate billing records. Only 429 (rate-limit) is safe to
+                # retry for mutations because the request was explicitly rejected
+                # before being processed.
+                is_mutation = action in ("POST", "PUT")
+                if is_mutation:
+                    is_retriable = response.status_code == 429
+                else:
+                    is_retriable = (
+                        response.status_code >= 500 or response.status_code == 429
+                    )
                 if not is_retriable or attempt == effective_retries:
                     if self.raise_on_error:
                         last_response.raise_for_status()
@@ -858,7 +888,17 @@ class AsyncBlestaRequest:
         branch sees only its own last request. Returns ``None`` if no
         requests have been made in the current task context.
 
+        The ``"args"`` value has sensitive keys redacted (replaced with
+        ``"***"``) to prevent accidental credential leakage in logs or CLI
+        output. The actual request payload is not affected.
+
         :return: Dict with ``"url"`` and ``"args"`` keys, or ``None``
             if no requests have been made in this context.
         """
-        return _last_request_var.get(None)
+        info = _last_request_var.get(None)
+        if info is None:
+            return None
+        return {
+            "url": info["url"],
+            "args": _redact_args(info["args"]),
+        }

--- a/src/blesta_sdk/_client.py
+++ b/src/blesta_sdk/_client.py
@@ -27,6 +27,33 @@ DEFAULT_TIMEOUT = 30
 
 _IDEMPOTENT_METHODS = frozenset({"GET", "DELETE"})
 
+_SENSITIVE_KEYS = frozenset(
+    {
+        "password",
+        "passwd",
+        "pass",
+        "token",
+        "api_key",
+        "key",
+        "secret",
+        "card_number",
+        "card",
+        "cvv",
+        "cvc",
+        "account_number",
+        "routing_number",
+    }
+)
+
+
+def _redact_args(args: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of args with sensitive values replaced by '***'.
+
+    Does not modify the original dict. Safe to call on request payloads
+    for display/logging only.
+    """
+    return {k: "***" if k.lower() in _SENSITIVE_KEYS else v for k, v in args.items()}
+
 
 class BlestaRequest:
     """HTTP client for the Blesta REST API.
@@ -62,6 +89,13 @@ class BlestaRequest:
         :meth:`~blesta_sdk.BlestaResponse.raise_for_status` before
         returning, raising a :class:`~blesta_sdk.BlestaError` subclass
         on non-success responses. Defaults to ``False``.
+    :param allow_http: When ``True``, permits ``http://`` base URLs.
+        Defaults to ``False``. HTTP sends credentials in plaintext —
+        only enable this for local development or explicit test
+        environments.
+    :param discovery: Optional :class:`~blesta_sdk.BlestaDiscovery` instance
+        to use instead of the module-level singleton. Useful when loading
+        schemas from a custom path or when injecting a mock in tests.
     """
 
     def __init__(
@@ -76,7 +110,14 @@ class BlestaRequest:
         pool_maxsize: int = 10,
         auth_method: Literal["basic", "header"] = "basic",
         raise_on_error: bool = False,
+        allow_http: bool = False,
+        discovery: Any = None,
     ):
+        if url.startswith("http://") and not allow_http:
+            raise ValueError(
+                "base_url uses HTTP which sends credentials in plaintext. "
+                "Pass allow_http=True to explicitly permit this (local/dev only)."
+            )
         self.base_url = url.rstrip("/") + "/"
         self.user = user
         self.key = key
@@ -85,6 +126,7 @@ class BlestaRequest:
         self.retry_mutations = retry_mutations
         self.auth_method = auth_method
         self.raise_on_error = raise_on_error
+        self._discovery = discovery
         self._last_request: dict[str, Any] | None = None
         self.session = requests.Session()
         if auth_method == "header":
@@ -116,9 +158,14 @@ class BlestaRequest:
     def _validate_segment(segment: str, name: str) -> None:
         validate_segment(segment, name)
 
-    @staticmethod
-    def _get_discovery() -> Any:
-        """Return the module-level cached BlestaDiscovery singleton."""
+    def _get_discovery(self) -> Any:
+        """Return the BlestaDiscovery instance for this client.
+
+        Returns the instance passed at construction time if provided,
+        otherwise falls back to the module-level singleton.
+        """
+        if self._discovery is not None:
+            return self._discovery
         from blesta_sdk._discovery import _get_discovery
 
         return _get_discovery()
@@ -204,7 +251,7 @@ class BlestaRequest:
         self._validate_segment(model, "model")
         self._validate_segment(method, "method")
         url = f"{self.base_url}{model}/{method}.json"
-        self._last_request = {"url": url, "args": args}
+        self._last_request = {"url": url, "args": args.copy()}
 
         can_retry = self.retry_mutations or action in _IDEMPOTENT_METHODS
         effective_retries = self.max_retries if can_retry else 0
@@ -227,9 +274,18 @@ class BlestaRequest:
                     response.text, response.status_code, response.headers
                 )
 
-                is_retriable = (
-                    response.status_code >= 500 or response.status_code == 429
-                )
+                # Mutations (POST/PUT) must never be retried on 5xx — a server
+                # error does not guarantee the write failed, and retrying risks
+                # duplicate billing records. Only 429 (rate-limit) is safe to
+                # retry for mutations because the request was explicitly rejected
+                # before being processed.
+                is_mutation = action in ("POST", "PUT")
+                if is_mutation:
+                    is_retriable = response.status_code == 429
+                else:
+                    is_retriable = (
+                        response.status_code >= 500 or response.status_code == 429
+                    )
                 if not is_retriable or attempt == effective_retries:
                     if self.raise_on_error:
                         last_response.raise_for_status()
@@ -268,7 +324,7 @@ class BlestaRequest:
 
         if last_response is None:  # pragma: no cover
             raise RuntimeError("Retry loop exited without a response")
-        return last_response
+        return last_response  # pragma: no cover
 
     def iter_all(
         self,
@@ -576,15 +632,18 @@ class BlestaRequest:
         Uses :class:`~blesta_sdk.BlestaDiscovery` to resolve the correct
         HTTP method when *action* is ``None``. If the schema cannot
         resolve the method, falls back to a safe prefix-based heuristic
-        (e.g. ``get*`` -> GET, ``create*`` -> POST). If still ambiguous,
-        defaults to POST with a warning.
+        (e.g. ``get*`` -> GET, ``create*`` -> POST, ``delete*`` -> DELETE).
+        If the HTTP method cannot be determined from either source,
+        :exc:`ValueError` is raised — pass *action* explicitly to avoid this.
 
         :param model: API model (e.g., ``"clients"``).
         :param method: API method (e.g., ``"getList"``).
         :param args: Request parameters.
         :param action: Explicit HTTP method override. If ``None``,
-            the method is inferred from the schema.
+            the method is inferred from the schema or method name prefix.
         :return: Parsed API response.
+        :raises ValueError: When the HTTP method cannot be determined from
+            the schema or method name prefix and *action* is ``None``.
         """
         if action is None:
             from blesta_sdk._discovery import _infer_http_method
@@ -597,13 +656,10 @@ class BlestaRequest:
                 if inferred is not None:
                     action = inferred
                 else:
-                    action = "POST"
-                    logger.warning(
-                        "call(%s, %s): schema unavailable and method name "
-                        "is ambiguous; falling back to POST. Specify "
-                        "action explicitly to silence this warning.",
-                        model,
-                        method,
+                    raise ValueError(
+                        f"call({model!r}, {method!r}): HTTP method could not be"
+                        " determined from schema or method name prefix. Pass"
+                        " action= explicitly."
                     )
         return self.submit(model, method, args, action)  # type: ignore[arg-type]
 
@@ -614,17 +670,36 @@ class BlestaRequest:
         args: dict[str, Any] | None = None,
         start_page: int = 1,
     ) -> list[Any]:
-        """Paginate an API method, inferring the HTTP verb from the schema.
+        """Paginate an API method, validating via schema that it uses GET.
 
-        Convenience wrapper around :meth:`get_all` that uses schema
-        discovery to confirm the method should be called via GET.
+        Convenience wrapper around :meth:`get_all` that uses
+        :class:`~blesta_sdk.BlestaDiscovery` to confirm the method resolves
+        to GET before paginating. If the schema is unavailable, proceeds
+        with a debug log note. If the schema definitively says the method
+        is not GET (e.g., POST, PUT, DELETE), :exc:`ValueError` is raised.
 
         :param model: API model (e.g., ``"invoices"``).
         :param method: API method (e.g., ``"getList"``).
         :param args: Query parameters.
         :param start_page: Page number to start from.
         :return: List of all result items across all pages.
+        :raises ValueError: When the schema indicates the method is not GET.
         """
+        _sentinel = "_UNRESOLVED_"
+        disco = self._get_discovery()
+        http_method = disco.resolve_http_method(model, method, default=_sentinel)
+        if http_method == _sentinel:
+            logger.debug(
+                "call_all(%s, %s): schema unavailable, proceeding with GET.",
+                model,
+                method,
+            )
+        elif http_method != "GET":
+            raise ValueError(
+                f"call_all({model!r}, {method!r}): schema says HTTP method is"
+                f" {http_method!r}, not GET. Use get_all() directly or pass the"
+                " correct pagination method."
+            )
         return self.get_all(model, method, args, start_page)
 
     def count_for(
@@ -637,7 +712,8 @@ class BlestaRequest:
 
         Uses :class:`~blesta_sdk.BlestaDiscovery` to find the matching
         count method (e.g., ``"getList"`` -> ``"getListCount"``). Falls
-        back to ``list_method + "Count"`` if the schema is unavailable.
+        back to ``list_method + "Count"`` if the schema is unavailable,
+        with a warning log so callers can verify the endpoint exists.
 
         :param model: API model (e.g., ``"transactions"``).
         :param list_method: The list method to find a count for.
@@ -648,12 +724,28 @@ class BlestaRequest:
         count_method = disco.suggest_pagination_pair(model, list_method)
         if count_method is None:
             count_method = list_method + "Count"
+            logger.warning(
+                "count_for(%s, %s): no count method found in schema, "
+                "falling back to %r. Verify this endpoint exists.",
+                model,
+                list_method,
+                count_method,
+            )
         return self.count(model, count_method, args)
 
     def get_last_request(self) -> dict[str, Any] | None:
         """Return details of the last request made.
 
+        The ``"args"`` value has sensitive keys redacted (replaced with
+        ``"***"``) to prevent accidental credential leakage in logs or CLI
+        output. The actual request payload is not affected.
+
         :return: Dict with ``"url"`` and ``"args"`` keys, or ``None``
             if no requests have been made.
         """
-        return self._last_request
+        if self._last_request is None:
+            return None
+        return {
+            "url": self._last_request["url"],
+            "args": _redact_args(self._last_request["args"]),
+        }

--- a/src/blesta_sdk/_discovery.py
+++ b/src/blesta_sdk/_discovery.py
@@ -187,9 +187,15 @@ class BlestaDiscovery:
         :param data: Parsed schema dict with a ``"models"`` key.
         :param source: Source label (``"core"`` or ``"plugin"``).
         """
-        assert self._registry is not None
-        assert self._source_map is not None
-        assert self._pagination_map is not None
+        if (
+            self._registry is None
+            or self._source_map is None
+            or self._pagination_map is None
+        ):
+            raise RuntimeError(
+                "BlestaDiscovery: internal state not initialised — "
+                "_ingest_schema called before _registry was set up"
+            )
 
         models = data.get("models", {})
         if not isinstance(models, dict):
@@ -225,8 +231,10 @@ class BlestaDiscovery:
         :return: Sorted list of model names.
         """
         self._ensure_loaded()
-        assert self._registry is not None
-        assert self._source_map is not None
+        if self._registry is None or self._source_map is None:
+            raise RuntimeError(
+                "BlestaDiscovery: schema data unavailable after load attempt"
+            )
 
         if source is None:
             return sorted(self._registry.keys())
@@ -240,7 +248,10 @@ class BlestaDiscovery:
         :raises KeyError: If the model is not found.
         """
         self._ensure_loaded()
-        assert self._registry is not None
+        if self._registry is None:
+            raise RuntimeError(
+                "BlestaDiscovery: schema data unavailable after load attempt"
+            )
 
         model_data = self._registry.get(model)
         if model_data is None:
@@ -256,8 +267,10 @@ class BlestaDiscovery:
         :raises KeyError: If the model or method is not found.
         """
         self._ensure_loaded()
-        assert self._registry is not None
-        assert self._source_map is not None
+        if self._registry is None or self._source_map is None:
+            raise RuntimeError(
+                "BlestaDiscovery: schema data unavailable after load attempt"
+            )
 
         model_data = self._registry.get(model)
         if model_data is None:
@@ -295,7 +308,10 @@ class BlestaDiscovery:
         :return: HTTP method string (``"GET"``, ``"POST"``, etc.).
         """
         self._ensure_loaded()
-        assert self._registry is not None
+        if self._registry is None:
+            raise RuntimeError(
+                "BlestaDiscovery: schema data unavailable after load attempt"
+            )
 
         model_data = self._registry.get(model)
         if model_data is None:
@@ -317,7 +333,10 @@ class BlestaDiscovery:
         :return: The count method name, or ``None`` if no pair found.
         """
         self._ensure_loaded()
-        assert self._pagination_map is not None
+        if self._pagination_map is None:
+            raise RuntimeError(
+                "BlestaDiscovery: schema data unavailable after load attempt"
+            )
 
         pagination = self._pagination_map.get(model)
         if pagination is None:
@@ -326,16 +345,18 @@ class BlestaDiscovery:
 
     def generate_capabilities_report(
         self,
-        format: Literal["markdown", "json"] = "markdown",
+        output_format: Literal["markdown", "json"] = "markdown",
     ) -> str:
         """Generate a capabilities report of the full API surface.
 
-        :param format: Output format — ``"markdown"`` or ``"json"``.
+        :param output_format: Output format — ``"markdown"`` or ``"json"``.
         :return: Report string.
         """
         self._ensure_loaded()
-        assert self._registry is not None
-        assert self._source_map is not None
+        if self._registry is None or self._source_map is None:
+            raise RuntimeError(
+                "BlestaDiscovery: schema data unavailable after load attempt"
+            )
 
         report_data: list[dict[str, Any]] = []
         for model_name in sorted(self._registry.keys()):
@@ -356,7 +377,7 @@ class BlestaDiscovery:
                 }
             )
 
-        if format == "json":
+        if output_format == "json":
             return json.dumps(report_data, indent=2, sort_keys=True)
 
         # Markdown
@@ -387,8 +408,10 @@ class BlestaDiscovery:
         :return: Number of entries written.
         """
         self._ensure_loaded()
-        assert self._registry is not None
-        assert self._source_map is not None
+        if self._registry is None or self._source_map is None:
+            raise RuntimeError(
+                "BlestaDiscovery: schema data unavailable after load attempt"
+            )
 
         count = 0
         with open(path, "w") as f:

--- a/src/blesta_sdk/_env_config.py
+++ b/src/blesta_sdk/_env_config.py
@@ -1,0 +1,107 @@
+"""Environment-keyed configuration for dev / stage / live Blesta deployments.
+
+Provides :class:`BlestaEnvConfig` which resolves credentials from constructor
+keyword arguments first, then falls back to environment variables of the form
+``BLESTA_{ENV}_URL``, ``BLESTA_{ENV}_USER``, and ``BLESTA_{ENV}_KEY`` — where
+``{ENV}`` is the upper-cased environment name (``DEV``, ``STAGE``, or
+``LIVE``).
+
+There is **no fallback between environments**: credentials for ``live`` are
+never read when ``stage`` is requested, and so on.
+
+Usage::
+
+    from blesta_sdk import BlestaEnvConfig
+
+    cfg = BlestaEnvConfig("stage")
+    client = cfg.client()
+    resp = client.get("clients", "getList")
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    from ._client import BlestaRequest
+
+_VALID_ENVS = ("dev", "stage", "live")
+_EnvLiteral = Literal["dev", "stage", "live"]
+
+
+class BlestaEnvConfig:
+    """Resolve Blesta credentials for a named environment and create a client.
+
+    :param env: One of ``"dev"``, ``"stage"``, or ``"live"``.
+    :param url: API base URL.  If omitted, read from ``BLESTA_{ENV}_URL``.
+    :param user: API user.  If omitted, read from ``BLESTA_{ENV}_USER``.
+    :param key: API key.  If omitted, read from ``BLESTA_{ENV}_KEY``.
+    :raises ValueError: If *env* is not one of the three valid values, or if
+        any credential cannot be resolved.
+    """
+
+    def __init__(
+        self,
+        env: _EnvLiteral,
+        *,
+        url: str | None = None,
+        user: str | None = None,
+        key: str | None = None,
+    ) -> None:
+        if env not in _VALID_ENVS:
+            raise ValueError(f"env must be one of {_VALID_ENVS!r}, got {env!r}")
+        self._env = env
+        prefix = f"BLESTA_{env.upper()}"
+
+        self._url = url or os.environ.get(f"{prefix}_URL") or ""
+        self._user = user or os.environ.get(f"{prefix}_USER") or ""
+        self._key = key or os.environ.get(f"{prefix}_KEY") or ""
+
+        missing: list[str] = []
+        if not self._url:
+            missing.append(f"{prefix}_URL")
+        if not self._user:
+            missing.append(f"{prefix}_USER")
+        if not self._key:
+            missing.append(f"{prefix}_KEY")
+
+        if missing:
+            raise ValueError(
+                f"Missing required configuration for env={env!r}: " + ", ".join(missing)
+            )
+
+    @property
+    def env(self) -> str:
+        """The environment name (``'dev'``, ``'stage'``, or ``'live'``)."""
+        return self._env
+
+    @property
+    def url(self) -> str:
+        """Resolved API base URL."""
+        return self._url
+
+    @property
+    def user(self) -> str:
+        """Resolved API user."""
+        return self._user
+
+    def client(self, **kwargs: Any) -> BlestaRequest:
+        """Construct and return a :class:`~blesta_sdk.BlestaRequest` for this env.
+
+        Any keyword arguments are forwarded to :class:`~blesta_sdk.BlestaRequest`
+        (e.g. ``retry_mutations=True``, ``allow_http=True``).
+
+        :return: A configured :class:`~blesta_sdk.BlestaRequest` instance.
+        """
+        from ._client import BlestaRequest
+
+        return BlestaRequest(
+            url=self._url,
+            user=self._user,
+            key=self._key,
+            **kwargs,
+        )
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return f"BlestaEnvConfig(env={self._env!r}, url={self._url!r})"

--- a/src/blesta_sdk/_pagination.py
+++ b/src/blesta_sdk/_pagination.py
@@ -17,6 +17,10 @@ from blesta_sdk._response import BlestaResponse
 logger = logging.getLogger(__name__)
 
 _REPEAT_THRESHOLD = 3
+# Rolling window size for alternating-page detection.
+# Keeps a short history of recent page hashes to catch A→B→A→B loops
+# that would otherwise reset _repeat_count on every page.
+_WINDOW_SIZE = 6
 
 
 class PaginationState:
@@ -44,6 +48,8 @@ class PaginationState:
         self._on_error = on_error
         self._prev_data: list[Any] | None = None
         self._repeat_count = 0
+        # Rolling window of recent page-data hashes for alternating-loop detection.
+        self._page_hash_window: list[int] = []
 
     def has_next_page(self) -> bool:
         """Return ``True`` if the loop should fetch another page."""
@@ -76,14 +82,23 @@ class PaginationState:
 
         Must be called *before* yielding items.
 
+        Valid falsy scalars (``0``, ``False``, ``""``) are treated as
+        real data and do *not* terminate pagination.  Only ``None``,
+        ``[]``, and ``{}`` are considered empty terminal responses.
+
+        Also detects alternating-page loops (A→B→A→B…) by keeping a
+        short rolling window of recent page-data hashes.  The window
+        catches patterns that reset the consecutive-repeat counter.
+
         :return: ``True`` if iteration should stop.
         """
-        if not data:
+        if data is None or data == [] or data == {}:
             return True
 
         if not isinstance(data, list):
             return False
 
+        # --- Consecutive identical-page detection ---
         if self._prev_data is not None and data == self._prev_data:
             self._repeat_count += 1
             if self._repeat_count >= _REPEAT_THRESHOLD:
@@ -97,6 +112,32 @@ class PaginationState:
         else:
             self._repeat_count = 0
         self._prev_data = data
+
+        # --- Alternating-page loop detection (rolling window) ---
+        # Hash the page content and keep the last _WINDOW_SIZE hashes.
+        # If the window is full and contains only two distinct values
+        # that alternate perfectly, the pagination is stuck in a cycle.
+        try:
+            page_hash = hash(str(data))
+        except Exception:
+            page_hash = id(data)
+        self._page_hash_window.append(page_hash)
+        if len(self._page_hash_window) > _WINDOW_SIZE:
+            self._page_hash_window.pop(0)
+        if len(self._page_hash_window) == _WINDOW_SIZE:
+            unique = set(self._page_hash_window)
+            if len(unique) == 2:
+                # Check that the window is a pure alternation (A,B,A,B,…)
+                seq = self._page_hash_window
+                if all(seq[i] != seq[i + 1] for i in range(len(seq) - 1)):
+                    logger.error(
+                        "Pagination aborted: page %d stuck in alternating loop "
+                        "(last %d pages cycle between 2 distinct responses)",
+                        self.page,
+                        _WINDOW_SIZE,
+                    )
+                    return True
+
         return False
 
     def collect(self, data: Any) -> None:

--- a/src/blesta_sdk/_response.py
+++ b/src/blesta_sdk/_response.py
@@ -214,9 +214,24 @@ class BlestaResponse:
                 errors=self.errors(),
                 headers=self._headers,
             )
+        # Blesta can return HTTP 200 with validation errors in the body.
+        # These must not be silently treated as success.
+        errs = self.errors()
+        if errs:
+            raise BlestaAPIError(
+                "Blesta returned errors (HTTP 200)",
+                status_code=code,
+                errors=errs,
+                headers=self._headers,
+            )
 
     def errors(self) -> dict[str, Any] | None:
         """Extract error information from the response.
+
+        For HTTP 200 responses, Blesta may still return validation errors
+        in either a ``"errors"`` key (plural, Blesta validation failures)
+        or an ``"error"`` key (singular, SDK parse failures).  Both are
+        surfaced so callers can distinguish success from failure reliably.
 
         :return: Dict of errors, or ``None`` on success.
         """
@@ -229,6 +244,10 @@ class BlestaResponse:
             return formatted.get(
                 "errors", {"error": f"HTTP {self._status_code} with no error details"}
             )
+        # HTTP 200: Blesta validation failures come back as {"errors": {...}}
+        if "errors" in formatted:
+            return formatted["errors"]
+        # SDK-internal parse failure sentinel {"error": "..."}
         if "error" in formatted:
             return {"error": formatted["error"]}
         return None

--- a/src/blesta_sdk/_validation.py
+++ b/src/blesta_sdk/_validation.py
@@ -37,3 +37,8 @@ def validate_segment(segment: str, name: str) -> None:
         raise ValueError(f"{name} cannot contain '?'")
     if "#" in segment:
         raise ValueError(f"{name} cannot contain '#'")
+    if "%" in segment:
+        raise ValueError(
+            f"{name} cannot contain percent-encoded characters "
+            "(e.g. %2F, %2e%2e, %00)"
+        )

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -636,14 +636,19 @@ async def test_async_iter_all_start_page(async_api):
     )
 
 
-async def test_async_iter_all_stops_on_falsy_data(async_api):
-    """iter_all treats falsy data (0, False) as end-of-pages."""
+async def test_async_iter_all_yields_falsy_scalar_data(async_api):
+    """iter_all yields falsy scalars (0, False) rather than treating them as empty.
+
+    Previously this test asserted result == [] which was the buggy behavior:
+    falsy scalars were silently dropped instead of being yielded (#10).
+    Non-list responses are yielded as a single item and stop pagination.
+    """
     mock_response = Mock(text=json.dumps({"response": 0}), status_code=200)
     with patch.object(
         async_api.client, "get", new_callable=AsyncMock, return_value=mock_response
     ):
         result = [item async for item in async_api.iter_all("invoices", "getList")]
-    assert result == []
+    assert result == [0]
 
 
 # --- extract() edge cases ---
@@ -1146,8 +1151,35 @@ async def test_async_post_not_retried_by_default(mock_sleep, _mock_random):
 
 @patch("blesta_sdk._async_client.random.random", return_value=1.0)
 @patch("blesta_sdk._async_client.asyncio.sleep", new_callable=AsyncMock)
-async def test_async_retry_mutations(mock_sleep, _mock_random):
-    """POST is retried when retry_mutations=True."""
+async def test_async_retry_mutations_does_not_retry_on_5xx(mock_sleep, _mock_random):
+    """POST with retry_mutations=True must NOT retry on 5xx (#12).
+
+    A 5xx does not guarantee the write never reached Blesta; retrying
+    risks duplicating billing records.
+    """
+    api = AsyncBlestaRequest(
+        "https://example.com/api",
+        "u",
+        "k",
+        max_retries=3,
+        retry_mutations=True,
+    )
+    with patch.object(
+        api.client,
+        "post",
+        new_callable=AsyncMock,
+        return_value=Mock(text="error", status_code=500),
+    ) as mock_post:
+        response = await api.post("clients", "create")
+    assert response.status_code == 500
+    assert mock_post.call_count == 1, "POST must not be retried on 5xx"
+    mock_sleep.assert_not_called()
+
+
+@patch("blesta_sdk._async_client.random.random", return_value=1.0)
+@patch("blesta_sdk._async_client.asyncio.sleep", new_callable=AsyncMock)
+async def test_async_retry_mutations_retries_on_429(mock_sleep, _mock_random):
+    """POST with retry_mutations=True DOES retry on 429 (rate-limit)."""
     api = AsyncBlestaRequest(
         "https://example.com/api",
         "u",
@@ -1156,15 +1188,14 @@ async def test_async_retry_mutations(mock_sleep, _mock_random):
         retry_mutations=True,
     )
     responses = [
-        Mock(text="error", status_code=500),
-        Mock(text='{"response": "ok"}', status_code=200),
+        Mock(text='{"error": "rate limited"}', status_code=429, headers={}),
+        Mock(text='{"response": "ok"}', status_code=200, headers={}),
     ]
     with patch.object(
         api.client, "post", new_callable=AsyncMock, side_effect=responses
     ):
         response = await api.post("clients", "create")
     assert response.status_code == 200
-    mock_sleep.assert_called_once()
 
 
 # --- get_all_fast verify ---
@@ -1532,3 +1563,144 @@ async def test_async_raise_on_error_429_has_retry_after():
         await api.get("clients", "getList")
     assert exc_info.value.retry_after == 30
     assert exc_info.value.headers["Retry-After"] == "30"
+
+
+# --- Lane 3: HTTP opt-in and path validation hardening (#11, #16) ---
+
+
+def test_async_http_base_url_raises_by_default():
+    """http:// base URL must raise ValueError without allow_http=True."""
+    with pytest.raises(ValueError, match="plaintext"):
+        AsyncBlestaRequest("http://example.com/api", "user", "key")
+
+
+def test_async_http_base_url_allowed_with_flag():
+    """http:// base URL is permitted when allow_http=True."""
+    api = AsyncBlestaRequest("http://example.com/api", "user", "key", allow_http=True)
+    assert api.base_url == "http://example.com/api/"
+
+
+def test_async_https_base_url_accepted_by_default():
+    """https:// base URL requires no special flag."""
+    api = AsyncBlestaRequest("https://example.com/api", "user", "key")
+    assert api.base_url.startswith("https://")
+
+
+@pytest.mark.parametrize(
+    "model,method",
+    [
+        ("%2Fadmin", "getList"),
+        ("clients", "%2e%2epasswd"),
+        ("%00", "getList"),
+        ("clients", "%2F%2F"),
+        ("%2f", "getList"),
+    ],
+)
+async def test_async_url_validation_rejects_percent_encoded(model, method):
+    """Percent-encoded path traversal is rejected in async client (#16)."""
+    api = AsyncBlestaRequest("https://example.com/api", "user", "key")
+    with pytest.raises(ValueError, match="percent"):
+        await api.submit(model, method)
+
+
+# --- Lane 7: last_request copy semantics and redaction (#19) ---
+
+
+async def test_async_last_request_args_are_copied(async_api):
+    """Mutating args after submit does not change last_request."""
+    args = {"client_id": 1}
+    mock_response = Mock(text='{"response": {}}', status_code=200, headers={})
+    with patch.object(
+        async_api.client, "get", new_callable=AsyncMock, return_value=mock_response
+    ):
+        await async_api.get("clients", "getList", args)
+    args["client_id"] = 999  # mutate original
+    last = async_api.get_last_request()
+    assert (
+        last["args"]["client_id"] == 1
+    ), "last_request must not reflect post-call mutation"
+
+
+@pytest.mark.parametrize(
+    "sensitive_key",
+    [
+        "password",
+        "passwd",
+        "pass",
+        "token",
+        "api_key",
+        "key",
+        "secret",
+        "card_number",
+        "card",
+        "cvv",
+        "cvc",
+        "account_number",
+        "routing_number",
+    ],
+)
+async def test_async_last_request_redacts_sensitive_keys(async_api, sensitive_key):
+    """Sensitive args are redacted in get_last_request() output (#19)."""
+    args = {sensitive_key: "super-secret-value", "page": 1}
+    mock_response = Mock(text='{"response": {}}', status_code=200, headers={})
+    with patch.object(
+        async_api.client, "post", new_callable=AsyncMock, return_value=mock_response
+    ):
+        await async_api.post("clients", "create", args)
+    last = async_api.get_last_request()
+    assert last["args"][sensitive_key] == "***"
+    assert last["args"]["page"] == 1
+
+
+async def test_async_last_request_non_sensitive_keys_pass_through(async_api):
+    """Non-sensitive args are not redacted."""
+    args = {"client_id": 42, "status": "active"}
+    mock_response = Mock(text='{"response": {}}', status_code=200, headers={})
+    with patch.object(
+        async_api.client, "get", new_callable=AsyncMock, return_value=mock_response
+    ):
+        await async_api.get("clients", "getList", args)
+    last = async_api.get_last_request()
+    assert last["args"]["client_id"] == 42
+    assert last["args"]["status"] == "active"
+
+
+# --- #28: async header auth — client.auth should be None ---
+
+
+def test_async_header_auth_sets_auth_none():
+    """auth_method='header' means client.auth is None (#28)."""
+    api = AsyncBlestaRequest(
+        "https://example.com/api", "myuser", "mykey", auth_method="header"
+    )
+    assert api.client.auth is None
+    assert api.client.headers.get("BLESTA-API-USER") == "myuser"
+    assert api.client.headers.get("BLESTA-API-KEY") == "mykey"
+
+
+# --- #31: get_all_fast(verify=True) count-mismatch path logs warning ---
+
+
+async def test_get_all_fast_verify_count_mismatch_logs_warning(caplog, async_api):
+    """get_all_fast(verify=True) logs warning when count changes (#31)."""
+    import logging
+
+    count1 = Mock(text=json.dumps({"response": 25}), status_code=200)
+    page_data = [{"id": i} for i in range(25)]
+    page_resp = Mock(text=json.dumps({"response": page_data}), status_code=200)
+    count2 = Mock(text=json.dumps({"response": 30}), status_code=200)
+
+    with (
+        patch.object(
+            async_api.client,
+            "get",
+            new_callable=AsyncMock,
+            side_effect=[count1, page_resp, count2],
+        ),
+        caplog.at_level(logging.WARNING),
+    ):
+        result = await async_api.get_all_fast(
+            "clients", "getList", verify=True, page_size=25
+        )
+    assert len(result) == 25
+    assert any("count changed" in r.message for r in caplog.records)

--- a/tests/test_blesta_sdk.py
+++ b/tests/test_blesta_sdk.py
@@ -1,7 +1,7 @@
 import json
 import os
 import sys
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 import requests
@@ -28,6 +28,7 @@ def test_all_exports():
         "BlestaAuthError",
         "BlestaConnectionError",
         "BlestaDiscovery",
+        "BlestaEnvConfig",
         "BlestaError",
         "BlestaRateLimitError",
         "BlestaRequest",
@@ -441,8 +442,13 @@ def test_iter_all_stops_on_none_response(blesta_request):
     assert result == []
 
 
-def test_iter_all_stops_on_falsy_data(blesta_request):
-    """iter_all treats falsy data (0, False) as end-of-pages."""
+def test_iter_all_yields_falsy_scalar_data(blesta_request):
+    """iter_all yields falsy scalars (0, False) rather than treating them as empty.
+
+    Previously this test asserted result == [] which was the buggy behavior:
+    falsy scalars were silently dropped instead of being yielded (#10).
+    Non-list responses are yielded as a single item and stop pagination.
+    """
     responses = [
         BlestaResponse(json.dumps({"response": 0}), 200),
     ]
@@ -450,7 +456,7 @@ def test_iter_all_stops_on_falsy_data(blesta_request):
     with patch.object(blesta_request, "get", side_effect=responses):
         result = list(blesta_request.iter_all("invoices", "getList"))
 
-    assert result == []
+    assert result == [0]
 
 
 def test_iter_all_forwards_args(blesta_request):
@@ -1540,19 +1546,16 @@ def test_call_heuristic_fallback(blesta_request):
     mock_delete.assert_called_once()
 
 
-def test_call_ambiguous_method_defaults_to_post(blesta_request):
-    """call() defaults to POST with warning when method name is ambiguous."""
+def test_call_ambiguous_method_raises_value_error(blesta_request):
+    """call() raises ValueError when method prefix is ambiguous (#20)."""
     with (
-        patch.object(blesta_request.session, "post") as mock_post,
         patch(
             "blesta_sdk._discovery.BlestaDiscovery.resolve_http_method",
             return_value="_UNRESOLVED_",
         ),
+        pytest.raises(ValueError, match="could not be determined"),
     ):
-        mock_post.return_value = Mock(text='{"response": null}', status_code=200)
-        response = blesta_request.call("clients", "doSomething")
-    assert response.status_code == 200
-    mock_post.assert_called_once()
+        blesta_request.call("clients", "doSomething")
 
 
 @pytest.mark.integration
@@ -1858,8 +1861,50 @@ def test_put_not_retried_by_default(mock_sleep, _mock_random):
 
 @patch("blesta_sdk._client.random.random", return_value=1.0)
 @patch("blesta_sdk._client.time.sleep")
-def test_retry_mutations_enables_post_retry(mock_sleep, _mock_random):
-    """POST is retried when retry_mutations=True."""
+def test_retry_mutations_does_not_retry_post_on_5xx(mock_sleep, _mock_random):
+    """POST with retry_mutations=True must NOT retry on 5xx (#12).
+
+    A 5xx does not guarantee the write never reached Blesta; retrying
+    can duplicate billing records. 5xx mutations return immediately.
+    """
+    api = BlestaRequest(
+        "https://test.example.com/api",
+        "u",
+        "k",
+        max_retries=3,
+        retry_mutations=True,
+    )
+    with patch.object(api.session, "post") as mock_post:
+        mock_post.return_value = Mock(text="error", status_code=500)
+        response = api.post("clients", "create")
+    assert response.status_code == 500
+    assert mock_post.call_count == 1, "POST must not be retried on 5xx"
+    mock_sleep.assert_not_called()
+
+
+@patch("blesta_sdk._client.random.random", return_value=1.0)
+@patch("blesta_sdk._client.time.sleep")
+def test_retry_mutations_does_not_retry_put_on_5xx(mock_sleep, _mock_random):
+    """PUT with retry_mutations=True must NOT retry on 5xx (#12)."""
+    api = BlestaRequest(
+        "https://test.example.com/api",
+        "u",
+        "k",
+        max_retries=3,
+        retry_mutations=True,
+    )
+    with patch.object(api.session, "put") as mock_put:
+        mock_put.return_value = Mock(text="error", status_code=503)
+        response = api.put("clients", "edit")
+    assert response.status_code == 503
+    assert mock_put.call_count == 1, "PUT must not be retried on 5xx"
+    mock_sleep.assert_not_called()
+
+
+@patch("blesta_sdk._client.random.random", return_value=1.0)
+@patch("blesta_sdk._client.time.sleep")
+def test_retry_mutations_retries_post_on_429(mock_sleep, _mock_random):
+    """POST with retry_mutations=True DOES retry on 429 (rate-limit)."""
     api = BlestaRequest(
         "https://test.example.com/api",
         "u",
@@ -1869,13 +1914,32 @@ def test_retry_mutations_enables_post_retry(mock_sleep, _mock_random):
     )
     with patch.object(api.session, "post") as mock_post:
         mock_post.side_effect = [
-            Mock(text="error", status_code=500),
-            Mock(text='{"response": "ok"}', status_code=200),
+            Mock(text='{"error": "rate limited"}', status_code=429, headers={}),
+            Mock(text='{"response": "ok"}', status_code=200, headers={}),
         ]
         response = api.post("clients", "create")
     assert response.status_code == 200
     assert mock_post.call_count == 2
-    mock_sleep.assert_called_once()
+
+
+@patch("blesta_sdk._client.random.random", return_value=1.0)
+@patch("blesta_sdk._client.time.sleep")
+def test_get_retry_on_5xx_unchanged(mock_sleep, _mock_random):
+    """GET retry on 5xx behavior is unchanged (#12)."""
+    api = BlestaRequest(
+        "https://test.example.com/api",
+        "u",
+        "k",
+        max_retries=1,
+    )
+    with patch.object(api.session, "get") as mock_get:
+        mock_get.side_effect = [
+            Mock(text="error", status_code=500, headers={}),
+            Mock(text='{"response": []}', status_code=200, headers={}),
+        ]
+        response = api.get("clients", "getList")
+    assert response.status_code == 200
+    assert mock_get.call_count == 2
 
 
 @patch("blesta_sdk._client.random.random", return_value=0.0)
@@ -2273,5 +2337,394 @@ def test_raise_on_error_false_returns_response():
     assert response.status_code == 400
 
 
+# --- Pagination integrity: falsy scalar payloads (#10) ---
+
+
+@pytest.mark.parametrize(
+    "scalar",
+    [
+        0,
+        False,
+        "",
+    ],
+)
+def test_iter_all_falsy_scalar_not_dropped(blesta_request, scalar):
+    """Falsy scalars (0, False, '') must be yielded, not silently dropped.
+
+    Previously `if not data` returned True and the scalar was discarded
+    without being yielded.  Non-list responses are yielded and then stop
+    pagination (by design); the regression was the silent drop.
+    """
+    import json
+
+    responses = [
+        Mock(text=json.dumps({"response": scalar}), status_code=200),
+    ]
+    with patch.object(blesta_request.session, "get", side_effect=responses):
+        result = list(blesta_request.iter_all("clients", "getList"))
+    # The scalar must appear in the result — it was real data, not an empty page.
+    assert (
+        scalar in result
+    ), f"Falsy scalar {scalar!r} was silently dropped instead of being yielded"
+
+
+def test_iter_all_none_terminates(blesta_request):
+    """None data must terminate pagination (real empty signal)."""
+    responses = [
+        Mock(text=json.dumps({"response": None}), status_code=200),
+    ]
+    with patch.object(blesta_request.session, "get", side_effect=responses):
+        result = list(blesta_request.iter_all("clients", "getList"))
+    assert result == []
+
+
+def test_iter_all_empty_list_terminates(blesta_request):
+    """Empty list must terminate pagination."""
+    responses = [
+        Mock(text=json.dumps({"response": [{"id": 1}]}), status_code=200),
+        Mock(text=json.dumps({"response": []}), status_code=200),
+    ]
+    with patch.object(blesta_request.session, "get", side_effect=responses):
+        result = list(blesta_request.iter_all("clients", "getList"))
+    assert result == [{"id": 1}]
+
+
+def test_iter_all_empty_dict_terminates(blesta_request):
+    """Empty dict must terminate pagination."""
+    responses = [
+        Mock(text=json.dumps({"response": {}}), status_code=200),
+    ]
+    with patch.object(blesta_request.session, "get", side_effect=responses):
+        result = list(blesta_request.iter_all("clients", "getList"))
+    assert result == []
+
+
+# --- Pagination integrity: alternating stuck-page detection (#17) ---
+
+
+def test_iter_all_alternating_page_loop_detected(blesta_request):
+    """Alternating pages A→B→A→B… must be detected and aborted.
+
+    The rolling-window detector should catch this after _WINDOW_SIZE pages.
+    """
+    page_a = [{"id": 1}]
+    page_b = [{"id": 2}]
+    # 12 alternating responses — well past the 6-page window
+    responses = []
+    for i in range(12):
+        data = page_a if i % 2 == 0 else page_b
+        responses.append(Mock(text=json.dumps({"response": data}), status_code=200))
+
+    with patch.object(blesta_request.session, "get", side_effect=responses) as mock_get:
+        result = list(blesta_request.iter_all("clients", "getList"))
+        calls_made = mock_get.call_count
+
+    # Should abort after the window fills (6 pages) + 1 detection page = 7 at most
+    assert calls_made <= 7, f"Expected abort within 7 pages, got {calls_made}"
+    # Items from the aborted pages: at most 6 pages × 1 item each
+    assert len(result) <= 6
+
+
+# --- Lane 3: HTTP opt-in and path validation hardening (#11, #16) ---
+
+
+def test_http_base_url_raises_by_default():
+    """http:// base URL must raise ValueError without allow_http=True."""
+    with pytest.raises(ValueError, match="plaintext"):
+        BlestaRequest("http://example.com/api", "user", "key")
+
+
+def test_http_base_url_allowed_with_flag():
+    """http:// base URL is permitted when allow_http=True."""
+    api = BlestaRequest("http://example.com/api", "user", "key", allow_http=True)
+    assert api.base_url == "http://example.com/api/"
+
+
+def test_https_base_url_accepted_by_default():
+    """https:// base URL requires no special flag."""
+    api = BlestaRequest("https://example.com/api", "user", "key")
+    assert api.base_url.startswith("https://")
+
+
+@pytest.mark.parametrize(
+    "model,method",
+    [
+        ("%2Fadmin", "getList"),
+        ("clients", "%2e%2epasswd"),
+        ("%00", "getList"),
+        ("clients", "%2F%2F"),
+        ("%2f", "getList"),
+    ],
+)
+def test_url_validation_rejects_percent_encoded(blesta_request, model, method):
+    """Percent-encoded path traversal is rejected (#16)."""
+    with pytest.raises(ValueError, match="percent"):
+        blesta_request.submit(model, method)
+
+
 if __name__ == "__main__":
     pytest.main(["-v"])
+
+
+# --- #24: HTTP 200 with {"errors":{}} treated as success ---
+
+
+def test_200_empty_errors_dict_is_success():
+    """HTTP 200 with {"errors":{}} is treated as success, not an error (#24)."""
+    resp = BlestaResponse('{"errors": {}}', 200)
+    errs = resp.errors()
+    assert not errs  # empty dict is falsy — treated as success
+    # raise_for_status() must not raise for empty errors
+    resp.raise_for_status()
+
+
+def test_200_empty_errors_dict_data_is_none():
+    """HTTP 200 with {"errors":{}} has no data (#24)."""
+    resp = BlestaResponse('{"errors": {}}', 200)
+    assert resp.data is None
+
+
+# --- #25: Non-integer Retry-After header ---
+
+
+@patch("blesta_sdk._client.random.random", return_value=1.0)
+@patch("blesta_sdk._client.time.sleep")
+def test_retry_after_float_does_not_crash(mock_sleep, _mock_random):
+    """Non-integer Retry-After header (e.g. float) does not crash (#25)."""
+    api = BlestaRequest("https://test.example.com/api", "u", "k", max_retries=1)
+    with patch.object(api.session, "get") as mock_get:
+        mock_get.side_effect = [
+            Mock(
+                text='{"error": "rate limited"}',
+                status_code=429,
+                headers={"Retry-After": "1.5"},
+            ),
+            Mock(text='{"response": []}', status_code=200, headers={}),
+        ]
+        response = api.get("clients", "getList")
+    assert response.status_code == 200
+
+
+@patch("blesta_sdk._client.random.random", return_value=1.0)
+@patch("blesta_sdk._client.time.sleep")
+def test_retry_after_http_date_does_not_crash(mock_sleep, _mock_random):
+    """HTTP-date Retry-After header does not crash (#25)."""
+    api = BlestaRequest("https://test.example.com/api", "u", "k", max_retries=1)
+    with patch.object(api.session, "get") as mock_get:
+        mock_get.side_effect = [
+            Mock(
+                text='{"error": "rate limited"}',
+                status_code=429,
+                headers={"Retry-After": "Wed, 21 Oct 2099 07:28:00 GMT"},
+            ),
+            Mock(text='{"response": []}', status_code=200, headers={}),
+        ]
+        response = api.get("clients", "getList")
+    assert response.status_code == 200
+
+
+# --- #26: iter_all with on_error='raise' on page-1 failure ---
+
+
+def test_iter_all_on_error_raise_page1_failure(blesta_request):
+    """iter_all with on_error='raise' raises PaginationError on page-1 failure (#26)."""
+    from blesta_sdk import PaginationError
+
+    with patch.object(blesta_request.session, "get") as mock_get:
+        mock_get.return_value = Mock(
+            text='{"error": "forbidden"}', status_code=403, headers={}
+        )
+        with pytest.raises(PaginationError) as exc_info:
+            list(blesta_request.iter_all("clients", "getList", on_error="raise"))
+    assert exc_info.value.page == 1
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.partial_items == []
+
+
+# --- #27: SSL error path ---
+
+
+def test_submit_ssl_error_returns_status_0(blesta_request):
+    """SSL errors are caught and returned as status_code=0 (#27)."""
+    with patch.object(blesta_request.session, "get") as mock_get:
+        mock_get.side_effect = requests.exceptions.SSLError("SSL handshake failed")
+        response = blesta_request.get("clients", "getList")
+    assert response.status_code == 0
+    assert "SSL" in response.raw
+
+
+# --- #29: to_dataframe() after free_raw() ---
+
+
+def test_to_dataframe_after_free_raw():
+    """to_dataframe() still works after free_raw() (#29)."""
+    pytest.importorskip("pandas")
+    resp = BlestaResponse('{"response": [{"id": 1, "name": "Alice"}]}', 200)
+    resp.free_raw()
+    assert resp.raw == ""
+    df = resp.to_dataframe()
+    assert len(df) == 1
+    assert "id" in df.columns
+
+
+# --- #30: retry_mutations=True with successful first POST must NOT retry ---
+
+
+@patch("blesta_sdk._client.random.random", return_value=1.0)
+@patch("blesta_sdk._client.time.sleep")
+def test_retry_mutations_no_retry_on_success(mock_sleep, _mock_random):
+    """POST with retry_mutations=True succeeds on attempt 1, does not retry (#30)."""
+    api = BlestaRequest(
+        "https://test.example.com/api", "u", "k", max_retries=3, retry_mutations=True
+    )
+    with patch.object(api.session, "post") as mock_post:
+        mock_post.return_value = Mock(
+            text='{"response": {"id": 1}}', status_code=200, headers={}
+        )
+        response = api.post("clients", "create", {"name": "Test"})
+    assert response.status_code == 200
+    assert mock_post.call_count == 1, "Successful POST must not be retried"
+    mock_sleep.assert_not_called()
+
+
+# --- Lane 8: API semantics cleanup (#18, #20, #21) ---
+
+
+def test_call_raises_for_unknown_method(blesta_request):
+    """call() raises ValueError when method is unrecognized (#20)."""
+    mock_disco = MagicMock()
+    mock_disco.resolve_http_method.return_value = "_UNRESOLVED_"
+    with (
+        patch.object(blesta_request, "_get_discovery", return_value=mock_disco),
+        pytest.raises(ValueError, match="could not be determined"),
+    ):
+        blesta_request.call("clients", "xyzUnknownOp")
+
+
+def test_call_all_raises_for_non_get_method(blesta_request):
+    """call_all() raises ValueError when schema says method is POST (#18)."""
+    mock_disco = MagicMock()
+    mock_disco.resolve_http_method.return_value = "POST"
+    with (
+        patch.object(blesta_request, "_get_discovery", return_value=mock_disco),
+        pytest.raises(ValueError, match="not GET"),
+    ):
+        blesta_request.call_all("clients", "create")
+
+
+def test_count_for_fallback_warns(blesta_request, caplog):
+    """count_for() logs warning when falling back to list_method+Count (#21)."""
+    import logging
+
+    mock_disco = MagicMock()
+    mock_disco.suggest_pagination_pair.return_value = None
+    with (
+        patch.object(blesta_request, "_get_discovery", return_value=mock_disco),
+        patch.object(blesta_request, "count", return_value=5) as mock_count,
+        caplog.at_level(logging.WARNING),
+    ):
+        result = blesta_request.count_for("clients", "getList")
+    assert result == 5
+    mock_count.assert_called_once_with("clients", "getListCount", None)
+    assert any("falling back" in r.message for r in caplog.records)
+
+
+# --- Lane 7: last_request copy semantics and redaction (#19) ---
+
+
+def test_last_request_args_are_copied(blesta_request):
+    """Mutating args after submit does not change last_request."""
+    args = {"client_id": 1}
+    with patch.object(blesta_request.session, "get") as mock:
+        mock.return_value = Mock(text='{"response": {}}', status_code=200, headers={})
+        blesta_request.get("clients", "getList", args)
+    args["client_id"] = 999  # mutate original
+    last = blesta_request.get_last_request()
+    assert (
+        last["args"]["client_id"] == 1
+    ), "last_request must not reflect post-call mutation"
+
+
+@pytest.mark.parametrize(
+    "sensitive_key",
+    [
+        "password",
+        "passwd",
+        "pass",
+        "token",
+        "api_key",
+        "key",
+        "secret",
+        "card_number",
+        "card",
+        "cvv",
+        "cvc",
+        "account_number",
+        "routing_number",
+    ],
+)
+def test_last_request_redacts_sensitive_keys(blesta_request, sensitive_key):
+    """Sensitive args are redacted in get_last_request() output (#19)."""
+    args = {sensitive_key: "super-secret-value", "page": 1}
+    with patch.object(blesta_request.session, "post") as mock:
+        mock.return_value = Mock(text='{"response": {}}', status_code=200, headers={})
+        blesta_request.post("clients", "create", args)
+    last = blesta_request.get_last_request()
+    assert last["args"][sensitive_key] == "***"
+    assert last["args"]["page"] == 1
+
+
+def test_last_request_non_sensitive_keys_pass_through(blesta_request):
+    """Non-sensitive args are not redacted."""
+    args = {"client_id": 42, "status": "active"}
+    with patch.object(blesta_request.session, "get") as mock:
+        mock.return_value = Mock(text='{"response": {}}', status_code=200, headers={})
+        blesta_request.get("clients", "getList", args)
+    last = blesta_request.get_last_request()
+    assert last["args"]["client_id"] == 42
+    assert last["args"]["status"] == "active"
+
+
+# ---------------------------------------------------------------------------
+# Coverage gap tests
+# ---------------------------------------------------------------------------
+
+
+def test_validate_segment_rejects_backslash():
+    """Line 35 in _validation.py: backslash check."""
+    api = BlestaRequest("https://example.com/api", "u", "k")
+    with pytest.raises(ValueError, match="backslash"):
+        api._validate_segment("clients\\admin", "model")
+
+
+def test_get_discovery_returns_injected_instance():
+    """Line 168 in _client.py: _get_discovery() returns self._discovery when set."""
+    mock_disc = MagicMock()
+    api = BlestaRequest("https://example.com/api", "u", "k", discovery=mock_disc)
+    assert api._get_discovery() is mock_disc
+
+
+def test_to_dataframe_empty_csv_returns_empty_dataframe():
+    """Line 140 in _response.py: to_dataframe() on a CSV response with empty rows."""
+    # has comma + 2 lines so is_csv=True, but force cache to empty list
+    resp = BlestaResponse("col1,col2\nval1,val2\n", 200)
+    resp._csv_cache = []  # override so csv_data returns []
+    df = resp.to_dataframe()
+    assert len(df) == 0
+
+
+def test_pagination_state_collect_page_non_list():
+    """Line 150 in _pagination.py: collect_page() appends dict data to collected."""
+    from blesta_sdk._pagination import PaginationState
+
+    state = PaginationState(start_page=1, max_pages=None, on_error="raise")
+    state.collect({"id": 1, "name": "Foo"})
+    assert state.collected == [{"id": 1, "name": "Foo"}]
+
+
+def test_errors_csv_non_200_status():
+    """Line 240 in _response.py: errors() on a CSV response with non-200 status."""
+    resp = BlestaResponse("col1,col2\nval1,val2\n", 500)
+    errs = resp.errors()
+    assert errs is not None
+    assert "500" in str(errs)

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -278,7 +278,7 @@ def test_suggest_pagination_pair_no_pagination_key(disco):
 
 
 def test_capabilities_report_markdown(disco):
-    report = disco.generate_capabilities_report(format="markdown")
+    report = disco.generate_capabilities_report(output_format="markdown")
     assert "# Blesta API Capabilities Report" in report
     assert "## Clients" in report
     assert "## Invoices" in report
@@ -290,7 +290,7 @@ def test_capabilities_report_markdown(disco):
 
 
 def test_capabilities_report_json(disco):
-    report = disco.generate_capabilities_report(format="json")
+    report = disco.generate_capabilities_report(output_format="json")
     data = json.loads(report)
     assert isinstance(data, list)
     model_names = [m["model"] for m in data]

--- a/tests/test_env_config.py
+++ b/tests/test_env_config.py
@@ -1,0 +1,195 @@
+"""Tests for BlestaEnvConfig (#14)."""
+
+from __future__ import annotations
+
+import pytest
+
+from blesta_sdk import BlestaEnvConfig, BlestaRequest
+
+# ---------------------------------------------------------------------------
+# Environment selection
+# ---------------------------------------------------------------------------
+
+
+def test_dev_env_selected(monkeypatch):
+    monkeypatch.setenv("BLESTA_DEV_URL", "https://dev.example.com/api")
+    monkeypatch.setenv("BLESTA_DEV_USER", "dev_user")
+    monkeypatch.setenv("BLESTA_DEV_KEY", "dev_key")
+    cfg = BlestaEnvConfig("dev")
+    assert cfg.env == "dev"
+    assert cfg.url == "https://dev.example.com/api"
+    assert cfg.user == "dev_user"
+
+
+def test_stage_env_selected(monkeypatch):
+    monkeypatch.setenv("BLESTA_STAGE_URL", "https://stage.example.com/api")
+    monkeypatch.setenv("BLESTA_STAGE_USER", "stage_user")
+    monkeypatch.setenv("BLESTA_STAGE_KEY", "stage_key")
+    cfg = BlestaEnvConfig("stage")
+    assert cfg.env == "stage"
+    assert cfg.url == "https://stage.example.com/api"
+
+
+def test_live_env_selected(monkeypatch):
+    monkeypatch.setenv("BLESTA_LIVE_URL", "https://live.example.com/api")
+    monkeypatch.setenv("BLESTA_LIVE_USER", "live_user")
+    monkeypatch.setenv("BLESTA_LIVE_KEY", "live_key")
+    cfg = BlestaEnvConfig("live")
+    assert cfg.env == "live"
+    assert cfg.url == "https://live.example.com/api"
+
+
+# ---------------------------------------------------------------------------
+# Invalid env raises
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_env_raises():
+    with pytest.raises(ValueError, match="must be one of"):
+        BlestaEnvConfig("prod")
+
+
+def test_empty_env_raises():
+    with pytest.raises(ValueError, match="must be one of"):
+        BlestaEnvConfig("")
+
+
+# ---------------------------------------------------------------------------
+# Missing credentials raise with variable names in message
+# ---------------------------------------------------------------------------
+
+
+def test_missing_url_raises(monkeypatch):
+    monkeypatch.delenv("BLESTA_DEV_URL", raising=False)
+    monkeypatch.setenv("BLESTA_DEV_USER", "u")
+    monkeypatch.setenv("BLESTA_DEV_KEY", "k")
+    with pytest.raises(ValueError, match="BLESTA_DEV_URL"):
+        BlestaEnvConfig("dev")
+
+
+def test_missing_user_raises(monkeypatch):
+    monkeypatch.setenv("BLESTA_DEV_URL", "https://dev.example.com/api")
+    monkeypatch.delenv("BLESTA_DEV_USER", raising=False)
+    monkeypatch.setenv("BLESTA_DEV_KEY", "k")
+    with pytest.raises(ValueError, match="BLESTA_DEV_USER"):
+        BlestaEnvConfig("dev")
+
+
+def test_missing_key_raises(monkeypatch):
+    monkeypatch.setenv("BLESTA_DEV_URL", "https://dev.example.com/api")
+    monkeypatch.setenv("BLESTA_DEV_USER", "u")
+    monkeypatch.delenv("BLESTA_DEV_KEY", raising=False)
+    with pytest.raises(ValueError, match="BLESTA_DEV_KEY"):
+        BlestaEnvConfig("dev")
+
+
+def test_all_missing_raises_all_var_names(monkeypatch):
+    for var in ("BLESTA_STAGE_URL", "BLESTA_STAGE_USER", "BLESTA_STAGE_KEY"):
+        monkeypatch.delenv(var, raising=False)
+    with pytest.raises(ValueError, match="BLESTA_STAGE_URL") as exc_info:
+        BlestaEnvConfig("stage")
+    msg = str(exc_info.value)
+    assert "BLESTA_STAGE_USER" in msg
+    assert "BLESTA_STAGE_KEY" in msg
+
+
+# ---------------------------------------------------------------------------
+# No fallback between environments
+# ---------------------------------------------------------------------------
+
+
+def test_stage_does_not_fall_back_to_live(monkeypatch):
+    """Stage credentials must not bleed into a live config request."""
+    for var in ("BLESTA_LIVE_URL", "BLESTA_LIVE_USER", "BLESTA_LIVE_KEY"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("BLESTA_STAGE_URL", "https://stage.example.com/api")
+    monkeypatch.setenv("BLESTA_STAGE_USER", "su")
+    monkeypatch.setenv("BLESTA_STAGE_KEY", "sk")
+    with pytest.raises(ValueError, match="BLESTA_LIVE"):
+        BlestaEnvConfig("live")
+
+
+def test_live_does_not_fall_back_to_dev(monkeypatch):
+    for var in ("BLESTA_DEV_URL", "BLESTA_DEV_USER", "BLESTA_DEV_KEY"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("BLESTA_LIVE_URL", "https://live.example.com/api")
+    monkeypatch.setenv("BLESTA_LIVE_USER", "lu")
+    monkeypatch.setenv("BLESTA_LIVE_KEY", "lk")
+    with pytest.raises(ValueError, match="BLESTA_DEV"):
+        BlestaEnvConfig("dev")
+
+
+def test_dev_does_not_fall_back_to_stage(monkeypatch):
+    for var in ("BLESTA_STAGE_URL", "BLESTA_STAGE_USER", "BLESTA_STAGE_KEY"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("BLESTA_DEV_URL", "https://dev.example.com/api")
+    monkeypatch.setenv("BLESTA_DEV_USER", "du")
+    monkeypatch.setenv("BLESTA_DEV_KEY", "dk")
+    with pytest.raises(ValueError, match="BLESTA_STAGE"):
+        BlestaEnvConfig("stage")
+
+
+# ---------------------------------------------------------------------------
+# Credential resolution: env vars vs explicit kwargs
+# ---------------------------------------------------------------------------
+
+
+def test_credentials_resolved_from_env_vars(monkeypatch):
+    monkeypatch.setenv("BLESTA_LIVE_URL", "https://live.example.com/api")
+    monkeypatch.setenv("BLESTA_LIVE_USER", "live_u")
+    monkeypatch.setenv("BLESTA_LIVE_KEY", "live_k")
+    cfg = BlestaEnvConfig("live")
+    assert cfg.url == "https://live.example.com/api"
+    assert cfg.user == "live_u"
+
+
+def test_explicit_kwargs_override_env_vars(monkeypatch):
+    monkeypatch.setenv("BLESTA_DEV_URL", "https://env.example.com/api")
+    monkeypatch.setenv("BLESTA_DEV_USER", "env_user")
+    monkeypatch.setenv("BLESTA_DEV_KEY", "env_key")
+    cfg = BlestaEnvConfig(
+        "dev",
+        url="https://override.example.com/api",
+        user="explicit_user",
+        key="explicit_key",
+    )
+    assert cfg.url == "https://override.example.com/api"
+    assert cfg.user == "explicit_user"
+
+
+# ---------------------------------------------------------------------------
+# client() construction
+# ---------------------------------------------------------------------------
+
+
+def test_client_returns_blesta_request(monkeypatch):
+    monkeypatch.setenv("BLESTA_DEV_URL", "https://dev.example.com/api")
+    monkeypatch.setenv("BLESTA_DEV_USER", "u")
+    monkeypatch.setenv("BLESTA_DEV_KEY", "k")
+    cfg = BlestaEnvConfig("dev")
+    client = cfg.client()
+    assert isinstance(client, BlestaRequest)
+
+
+def test_client_kwargs_forwarded(monkeypatch):
+    monkeypatch.setenv("BLESTA_DEV_URL", "https://dev.example.com/api")
+    monkeypatch.setenv("BLESTA_DEV_USER", "u")
+    monkeypatch.setenv("BLESTA_DEV_KEY", "k")
+    cfg = BlestaEnvConfig("dev")
+    client = cfg.client(retry_mutations=True)
+    assert client.retry_mutations is True
+
+
+# ---------------------------------------------------------------------------
+# repr
+# ---------------------------------------------------------------------------
+
+
+def test_repr_shows_env_and_url(monkeypatch):
+    monkeypatch.setenv("BLESTA_STAGE_URL", "https://stage.example.com/api")
+    monkeypatch.setenv("BLESTA_STAGE_USER", "su")
+    monkeypatch.setenv("BLESTA_STAGE_KEY", "sk")
+    cfg = BlestaEnvConfig("stage")
+    r = repr(cfg)
+    assert "stage" in r
+    assert "https://stage.example.com/api" in r

--- a/tests/test_response_edge_cases.py
+++ b/tests/test_response_edge_cases.py
@@ -352,3 +352,76 @@ class TestFormatResponseInvariant:
         r = make_response(body, 500)
         err = r.errors()
         assert err is not None
+
+
+# --- Blesta 200 validation error surfaces (#8, #24) ---
+
+
+class TestBlesta200ValidationErrors:
+    """HTTP 200 with Blesta error bodies must never look like success."""
+
+    def test_errors_plural_key_is_surfaced(self):
+        """200 + {"errors": {...}} must return errors, not None."""
+        r = make_response('{"errors": {"email": "Invalid email address"}}', 200)
+        errs = r.errors()
+        assert errs is not None
+        assert "email" in errs
+
+    def test_errors_plural_data_is_none(self):
+        """data is None when the body has no 'response' key."""
+        r = make_response('{"errors": {"email": "Invalid"}}', 200)
+        assert r.data is None
+
+    def test_errors_singular_internal_still_surfaced(self):
+        """200 + SDK-internal {"error": "..."} still returns errors."""
+        r = make_response('{"error": "Something went wrong"}', 200)
+        errs = r.errors()
+        assert errs is not None
+        assert "error" in errs
+
+    def test_successful_200_returns_none_errors(self):
+        """200 + {"response": [...]} must return None errors."""
+        r = make_response('{"response": [{"id": 1}]}', 200)
+        assert r.errors() is None
+        assert r.data == [{"id": 1}]
+
+    def test_malformed_json_200_surfaces_error(self):
+        """200 + malformed JSON must not silently return data=None, errors=None."""
+        r = make_response("not json at all", 200)
+        assert r.data is None
+        errs = r.errors()
+        assert errs is not None
+        assert "error" in errs
+
+    def test_raise_for_status_raises_on_200_errors_plural(self):
+        """raise_for_status() must raise for 200 + {"errors": {...}}."""
+        from blesta_sdk._exceptions import BlestaAPIError
+
+        r = make_response('{"errors": {"field": "bad"}}', 200)
+        with pytest.raises(BlestaAPIError) as exc_info:
+            r.raise_for_status()
+        assert exc_info.value.status_code == 200
+        assert exc_info.value.errors is not None
+
+    def test_raise_for_status_noop_on_clean_200(self):
+        """raise_for_status() must not raise for a clean 200 response."""
+        r = make_response('{"response": {"id": 42}}', 200)
+        r.raise_for_status()  # must not raise
+
+    def test_raise_for_status_raises_on_malformed_200(self):
+        """raise_for_status() must raise when 200 body is malformed JSON."""
+        from blesta_sdk._exceptions import BlestaAPIError
+
+        r = make_response("definitely not json", 200)
+        with pytest.raises(BlestaAPIError):
+            r.raise_for_status()
+
+    def test_errors_plural_multi_field(self):
+        """Multiple validation errors are all returned."""
+        body = '{"errors": {"email": "Invalid", "first_name": "Required"}}'
+        r = make_response(body, 200)
+        errs = r.errors()
+        assert errs is not None
+        assert len(errs) == 2
+        assert "email" in errs
+        assert "first_name" in errs

--- a/tools/extract_plugin_schema.py
+++ b/tools/extract_plugin_schema.py
@@ -29,7 +29,11 @@ logger = logging.getLogger(__name__)
 RAW_GITHUB_BASE = "https://raw.githubusercontent.com/blesta"
 GITHUB_BLOB_BASE = "https://github.com/blesta"
 DEFAULT_OUTPUT = (
-    Path(__file__).resolve().parent.parent / "schemas" / "blesta_plugin_schema.json"
+    Path(__file__).resolve().parent.parent
+    / "src"
+    / "blesta_sdk"
+    / "schemas"
+    / "blesta_plugin_schema.json"
 )
 SCHEMA_VERSION = "2.0.0"
 

--- a/tools/extract_schema.py
+++ b/tools/extract_schema.py
@@ -30,7 +30,11 @@ logger = logging.getLogger(__name__)
 BASE_URL = "https://source-docs.blesta.com"
 MODELS_URL = f"{BASE_URL}/packages/blesta-app-models.html"
 DEFAULT_OUTPUT = (
-    Path(__file__).resolve().parent.parent / "schemas" / "blesta_api_schema.json"
+    Path(__file__).resolve().parent.parent
+    / "src"
+    / "blesta_sdk"
+    / "schemas"
+    / "blesta_api_schema.json"
 )
 SCHEMA_VERSION = "2.0.0"
 


### PR DESCRIPTION
* fix(response): surface Blesta 200 validation errors (#8, #24)

* fix(pagination): preserve falsy scalar payloads, detect alternating loops (#10, #17)

* fix(client): require explicit HTTP opt-in, block percent-encoded paths (#11, #16)

* fix(client): don't retry mutations on 5xx, only 429 (#12)

* fix(discovery): replace assert guards with RuntimeError, rename format param (#9, #22, #23)

* fix(client): API semantics, last_request redaction/copy, async semaphore (#13, #15, #18, #19, #20, #21)

* fix(schemas): point extraction tools at canonical path, add weekly refresh CI workflow (#32)

* docs(migration): add idempotency design — ledger + check-then-create + source IDs (#33)

* feat(config): add BlestaEnvConfig for dev/stage/live environment selection (#14)

* tests: add coverage gap tests, mark unreachable retry return pragma no cover

* docs: add hardening sprint final report for external review

* docs(env_config): fix usage example — submit() args were in wrong order