### PR TITLE
docs: fix P0 stale examples after hardening sprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ disco.resolve_http_method("Clients", "create")         # "POST"
 disco.suggest_pagination_pair("Clients", "getList")    # "getListCount"
 
 # Generate a capabilities report
-print(disco.generate_capabilities_report(format="markdown"))
+print(disco.generate_capabilities_report(output_format="markdown"))
 
 # Generate JSONL index for AI embeddings
 disco.generate_ai_index("blesta_api_index.jsonl")
@@ -452,7 +452,7 @@ Same methods as `BlestaRequest`, all `async`. Additional async-specific methods:
 | `get_method_spec(model, method)` | Get full `MethodSpec` dataclass for a method |
 | `resolve_http_method(model, method, default="POST")` | Resolve HTTP method from schema |
 | `suggest_pagination_pair(model, list_method="getList")` | Find the count method for a list method |
-| `generate_capabilities_report(format="markdown")` | Generate API capabilities report |
+| `generate_capabilities_report(output_format="markdown")` | Generate API capabilities report |
 | `generate_ai_index(path)` | Write JSONL index for AI embeddings |
 
 ### `BlestaResponse`

--- a/SDK_USAGE.md
+++ b/SDK_USAGE.md
@@ -215,7 +215,7 @@ disco.resolve_http_method("Unknown", "unknown")        # "POST" (default)
 disco.suggest_pagination_pair("Clients", "getList")    # "getListCount"
 
 # Generate reports
-print(disco.generate_capabilities_report(format="markdown"))
+print(disco.generate_capabilities_report(output_format="markdown"))
 disco.generate_ai_index("blesta_api_index.jsonl")  # returns entry count
 ```
 

--- a/src/blesta_sdk/_env_config.py
+++ b/src/blesta_sdk/_env_config.py
@@ -15,7 +15,7 @@ Usage::
 
     cfg = BlestaEnvConfig("stage")
     client = cfg.client()
-    resp = client.submit("GET", "clients", "list")
+    resp = client.get("clients", "getList")
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Fixes two P0 documentation bugs identified in the 2026-05-27 QC report.

### Changes

**Fix #42 — `output_format=` rename (QC-F01)**
- `README.md` line 326: code example `generate_capabilities_report(format=...)` → `generate_capabilities_report(output_format=...)`
- `README.md` line 455: reference table entry updated to match
- `SDK_USAGE.md` line 218: code example updated to match

**Fix #43 — `_env_config.py` docstring (QC-F02)**
- `src/blesta_sdk/_env_config.py` module docstring: `client.submit("GET", "clients", "list")` → `client.get("clients", "getList")`

### No runtime changes
All edits are in documentation strings and markdown files only.

### Checks
- black: all files unchanged
- ruff: all checks passed
- pytest: 745 passed, 1 deselected (integration skipped)

Closes #42
Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)