### PR TITLE
docs: update retry, config, constructor, and changelog reality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `BlestaEnvConfig` — select credentials for a named deployment environment (`dev`, `stage`, or `live`) from environment variables (`BLESTA_{ENV}_URL/USER/KEY`) or constructor kwargs. `client()` returns a ready-to-use `BlestaRequest`. Requires `blesta_sdk[cli]` for `.env` file loading.
+- `_redaction.py` shared module — `redact_args()` extracted from `_client.py` into a dedicated module shared by both sync and async clients; eliminates cross-module import and keeps redaction logic in one place.
+
+### Changed
+- **Retry semantics clarified (breaking for any code relying on POST/PUT 5xx retry):** POST and PUT requests are never retried on 5xx responses, even when `retry_mutations=True`. A 5xx does not guarantee the write failed — retrying risks duplicate billing records. `retry_mutations=True` now enables retry on 429 (rate-limit) only for mutations. GET and DELETE continue to retry on both 5xx and 429.
+- `allow_http=True` is now required to use an `http://` base URL. Passing an HTTP URL without this flag raises `ValueError`. This protects credentials from being sent in plaintext by accident. **Breaking change** for any code using `http://` URLs without the flag.
+
+### Fixed
+- Response correctness: Blesta returns HTTP 200 with an `errors` key for validation failures (e.g., duplicate client). `BlestaResponse.errors()` now correctly surfaces these payloads. Previously, callers checking only `status_code == 200` could miss validation errors.
+- Pagination integrity: falsy scalar payloads (e.g., `0`, `false`) returned by `getListCount`-style methods no longer trigger a premature stop. Stuck-page detection now distinguishes an empty list response from a legitimate scalar.
+- Discovery runtime safety: `BlestaDiscovery` no longer uses bare `assert` statements for internal validation. All assertions replaced with `ValueError` / `RuntimeError` raises so errors surface cleanly in production (Python's `-O` flag strips asserts).
+- Async concurrency: `AsyncBlestaRequest.extract()` and `get_all_fast()` now gate all concurrent requests through the client-level semaphore (`max_concurrency`, default 10), preventing request storms when processing large target lists.
+- CLI redaction: `get_last_request()` redacts sensitive keys from `args` before returning. Previously, raw API key values could appear in debug/log output via `--last-request`.
+- Schema tooling: `extract_schema.py` and `extract_plugin_schema.py` now write to `src/blesta_sdk/schemas/` (the canonical bundled location) instead of the deprecated root `schemas/` directory.
+
+### Internal
+- Migration docs: `docs/` now includes idempotency design guidance for billing writes — ledger dedup and check-before-create patterns for safe retry in the face of server errors.
+
 ## [0.6.0] - 2026-03-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -268,9 +268,24 @@ For production pipelines, enable automatic retry with exponential backoff:
 ```python
 api = BlestaRequest(url, user, key, max_retries=3)
 
-# Retries on network errors, 5xx, and 429 responses (with jitter)
+# GET/DELETE: retry on network errors, 5xx, and 429 (with jitter)
 # Does NOT retry on other 4xx client errors
 response = api.get("clients", "getList")
+
+# POST/PUT: retry ONLY on 429 (rate-limit), never on 5xx
+# A 5xx does not guarantee the write failed — retrying risks duplicate billing records
+response = api.post("clients", "create", {"firstname": "John"})
+```
+
+By default, only GET and DELETE are retried (`retry_mutations=False`). Pass
+`retry_mutations=True` to include POST/PUT in the retry loop, but note that even
+then **POST/PUT will never retry on 5xx — only on 429**. To safely handle server
+errors on billing writes, use an idempotency pattern (ledger dedup or
+check-before-create) rather than relying on automatic retry.
+
+```python
+# retry_mutations=True: POST/PUT will retry on 429 but NOT on 5xx
+api = BlestaRequest(url, user, key, max_retries=3, retry_mutations=True)
 ```
 
 ### Rate Limiting
@@ -323,7 +338,7 @@ disco.resolve_http_method("Clients", "create")         # "POST"
 disco.suggest_pagination_pair("Clients", "getList")    # "getListCount"
 
 # Generate a capabilities report
-print(disco.generate_capabilities_report(format="markdown"))
+print(disco.generate_capabilities_report(output_format="markdown"))
 
 # Generate JSONL index for AI embeddings
 disco.generate_ai_index("blesta_api_index.jsonl")
@@ -369,6 +384,45 @@ async with AsyncBlestaRequest(url, user, key) as api:
 
 Constructor accepts `max_connections` and `max_keepalive_connections` (default `10`/`10`) instead of the sync `pool_connections`/`pool_maxsize`.
 
+## Environment Configuration
+
+`BlestaEnvConfig` selects credentials for a named deployment environment (dev, stage, or live) from environment variables or constructor keyword arguments.
+
+### Environment Variables
+
+| Environment | URL | User | Key |
+|---|---|---|---|
+| `dev` | `BLESTA_DEV_URL` | `BLESTA_DEV_USER` | `BLESTA_DEV_KEY` |
+| `stage` | `BLESTA_STAGE_URL` | `BLESTA_STAGE_USER` | `BLESTA_STAGE_KEY` |
+| `live` | `BLESTA_LIVE_URL` | `BLESTA_LIVE_USER` | `BLESTA_LIVE_KEY` |
+
+`.env` file support requires the `cli` extra (`pip install blesta_sdk[cli]`).
+
+### Key Behaviors
+
+- Credentials for each environment are **fully isolated** — missing vars for `stage` will never fall back to `live`.
+- Raises `ValueError` immediately if any of the three required vars are absent.
+- `client()` returns a fully configured `BlestaRequest`. Any keyword arguments are forwarded to the constructor (e.g. `allow_http=True`, `retry_mutations=True`).
+
+### Usage
+
+```python
+from blesta_sdk import BlestaEnvConfig
+
+cfg = BlestaEnvConfig("stage")
+api = cfg.client()
+response = api.get("clients", "getList")
+```
+
+Credentials can also be passed directly as keyword arguments:
+
+```python
+cfg = BlestaEnvConfig("dev", url="https://dev.example.com/api", user="u", key="k")
+api = cfg.client(max_retries=3)
+```
+
+See `.env.example` for a template covering all three environments.
+
 ## CLI
 
 The `blesta` command reads credentials from environment variables. With the `cli` extra installed (`pip install blesta_sdk[cli]`), it also loads a `.env` file in the current directory:
@@ -407,7 +461,7 @@ Output is JSON to stdout. On errors, the error dict is printed as JSON and the p
 
 ## API Reference
 
-### `BlestaRequest(url, user, key, timeout=30, max_retries=0, retry_mutations=False, pool_connections=10, pool_maxsize=10, auth_method="basic", raise_on_error=False)`
+### `BlestaRequest(url, user, key, timeout=30, max_retries=0, retry_mutations=False, pool_connections=10, pool_maxsize=10, auth_method="basic", raise_on_error=False, allow_http=False, discovery=None)`
 
 | Method | Description |
 |---|---|
@@ -432,7 +486,7 @@ Output is JSON to stdout. On errors, the error dict is printed as JSON and the p
 
 Supports context manager (`with BlestaRequest(...) as api:`).
 
-### `AsyncBlestaRequest(url, user, key, timeout=30, max_retries=0, retry_mutations=False, max_connections=10, max_keepalive_connections=10, max_concurrency=10, auth_method="basic", raise_on_error=False)`
+### `AsyncBlestaRequest(url, user, key, timeout=30, max_retries=0, retry_mutations=False, max_connections=10, max_keepalive_connections=10, max_concurrency=10, auth_method="basic", raise_on_error=False, allow_http=False, discovery=None)`
 
 Same methods as `BlestaRequest`, all `async`. Additional async-specific methods:
 
@@ -443,6 +497,26 @@ Same methods as `BlestaRequest`, all `async`. Additional async-specific methods:
 
 `extract()` runs targets concurrently via `asyncio.gather()`. `iter_all()` is an async generator (`async for`). Supports `async with` context manager.
 
+### `BlestaEnvConfig(env, *, url=None, user=None, key=None)`
+
+Resolves Blesta credentials for a named deployment environment.
+
+| Parameter | Description |
+|---|---|
+| `env` | One of `"dev"`, `"stage"`, or `"live"` |
+| `url` | API base URL — falls back to `BLESTA_{ENV}_URL` env var |
+| `user` | API user — falls back to `BLESTA_{ENV}_USER` env var |
+| `key` | API key — falls back to `BLESTA_{ENV}_KEY` env var |
+
+Raises `ValueError` if `env` is not recognized, or if any credential cannot be resolved.
+
+| Method / Property | Description |
+|---|---|
+| `client(**kwargs)` | Return a `BlestaRequest` for this environment. Extra kwargs forwarded to constructor. |
+| `env` | The environment name |
+| `url` | Resolved API base URL |
+| `user` | Resolved API user |
+
 ### `BlestaDiscovery(core_schema_path=None, plugin_schema_path=None)`
 
 | Method | Description |
@@ -452,7 +526,7 @@ Same methods as `BlestaRequest`, all `async`. Additional async-specific methods:
 | `get_method_spec(model, method)` | Get full `MethodSpec` dataclass for a method |
 | `resolve_http_method(model, method, default="POST")` | Resolve HTTP method from schema |
 | `suggest_pagination_pair(model, list_method="getList")` | Find the count method for a list method |
-| `generate_capabilities_report(format="markdown")` | Generate API capabilities report |
+| `generate_capabilities_report(output_format="markdown")` | Generate API capabilities report |
 | `generate_ai_index(path)` | Write JSONL index for AI embeddings |
 
 ### `BlestaResponse`

--- a/SDK_USAGE.md
+++ b/SDK_USAGE.md
@@ -15,8 +15,8 @@ api = BlestaRequest(
     key="api_key",
     auth_method="header",   # or "basic" (default)
     timeout=30,             # seconds, default 30
-    max_retries=3,          # exponential backoff with jitter on 5xx/network errors
-    retry_mutations=False,  # True to also retry POST/PUT (default: only GET/DELETE)
+    max_retries=3,          # GET/DELETE: retry on 5xx/network errors/429; POST/PUT: 429 only
+    retry_mutations=False,  # True to include POST/PUT in retry loop (429 only, never 5xx)
     pool_connections=10,    # connection pools to cache (default 10)
     pool_maxsize=10,        # max connections per pool (default 10)
 )
@@ -215,7 +215,7 @@ disco.resolve_http_method("Unknown", "unknown")        # "POST" (default)
 disco.suggest_pagination_pair("Clients", "getList")    # "getListCount"
 
 # Generate reports
-print(disco.generate_capabilities_report(format="markdown"))
+print(disco.generate_capabilities_report(output_format="markdown"))
 disco.generate_ai_index("blesta_api_index.jsonl")  # returns entry count
 ```
 
@@ -276,8 +276,10 @@ AsyncBlestaRequest(
     url, user, key,
     max_connections=10,              # instead of pool_connections
     max_keepalive_connections=10,    # instead of pool_maxsize
-    max_concurrency=10,             # shared semaphore for concurrent requests
-    retry_mutations=False,          # same as sync client
+    max_concurrency=10,              # shared semaphore for concurrent requests
+    retry_mutations=False,           # same as sync client (POST/PUT: 429 only, never 5xx)
+    allow_http=False,                # permit http:// URLs (local/dev only)
+    discovery=None,                  # inject custom BlestaDiscovery instance
 )
 ```
 

--- a/src/blesta_sdk/_async_client.py
+++ b/src/blesta_sdk/_async_client.py
@@ -52,12 +52,15 @@ class AsyncBlestaRequest:
     :param timeout: Request timeout in seconds. Applied at client
         initialization and cannot be changed afterward (unlike the sync
         client, where timeout is passed per-request).
-    :param max_retries: Number of retries on network errors or 5xx responses.
-        Only GET and DELETE are retried by default. Pass
-        ``retry_mutations=True`` to also retry POST/PUT.
+    :param max_retries: Number of retries on transient failures.
+        GET and DELETE retry on network errors, 5xx responses, and 429.
+        POST and PUT retry **only on 429** (rate-limit) — never on 5xx,
+        because a server error does not guarantee the write failed and
+        retrying risks duplicate billing records.
         Uses exponential backoff with jitter. Defaults to ``0`` (no retries).
-    :param retry_mutations: Allow retrying non-idempotent methods
-        (POST, PUT). Defaults to ``False``.
+    :param retry_mutations: Include POST and PUT in the retry loop.
+        When ``True``, POST/PUT will retry on 429 but still never on 5xx.
+        Defaults to ``False``.
     :param max_connections: Maximum number of connections in the pool.
         Defaults to ``10``.
     :param max_keepalive_connections: Maximum number of idle keep-alive

--- a/src/blesta_sdk/_client.py
+++ b/src/blesta_sdk/_client.py
@@ -45,12 +45,15 @@ class BlestaRequest:
     :param user: API username.
     :param key: API key.
     :param timeout: Request timeout in seconds.
-    :param max_retries: Number of retries on network errors or 5xx responses.
-        Only GET and DELETE are retried by default. Pass
-        ``retry_mutations=True`` to also retry POST/PUT.
+    :param max_retries: Number of retries on transient failures.
+        GET and DELETE retry on network errors, 5xx responses, and 429.
+        POST and PUT retry **only on 429** (rate-limit) — never on 5xx,
+        because a server error does not guarantee the write failed and
+        retrying risks duplicate billing records.
         Uses exponential backoff with jitter. Defaults to ``0`` (no retries).
-    :param retry_mutations: Allow retrying non-idempotent methods
-        (POST, PUT). Defaults to ``False``.
+    :param retry_mutations: Include POST and PUT in the retry loop.
+        When ``True``, POST/PUT will retry on 429 but still never on 5xx.
+        Defaults to ``False``.
     :param pool_connections: Number of connection pools to cache.
         Defaults to ``10``.
     :param pool_maxsize: Maximum number of connections per pool.


### PR DESCRIPTION
Fixes #47, #48, #49, #55

## Summary

Documentation-only changes. No runtime behavior modified.

### Fix #47 — Retry semantics

- README Retry section: rewrote to clearly state GET/DELETE retry on 5xx/network/429; POST/PUT retry **only on 429, never on 5xx**. Added explanation of why (duplicate billing risk) and note about idempotency patterns.
- `_client.py` and `_async_client.py` docstrings: updated `max_retries` and `retry_mutations` param descriptions to match actual behavior.
- SDK_USAGE.md: fixed inline comment on `max_retries` in the initialization example.

### Fix #48 — BlestaEnvConfig docs

Added "Environment Configuration" section to README with:
- Environment variable table (dev/stage/live × URL/USER/KEY)
- Key behaviors (env isolation, ValueError on missing vars, client() kwargs forwarding)
- Usage examples including direct-kwarg override
- API reference entry for `BlestaEnvConfig` constructor and methods

### Fix #49 — CHANGELOG [Unreleased]

Filled empty `[Unreleased]` section with post-hardening sprint entries covering:
- Response correctness (Blesta 200 validation errors)
- Pagination integrity (falsy scalar payloads, stuck-page detection)
- HTTP safety (`allow_http=True` opt-in) — marked as breaking change
- Retry semantics (POST/PUT 429-only) — marked as breaking change
- Discovery runtime safety (asserts → ValueError)
- Async concurrency (semaphore gating)
- CLI redaction (last_request redaction)
- Shared `_redaction.py` module
- `BlestaEnvConfig` addition
- Schema tooling canonical path fix
- Migration idempotency docs

### Fix #55 — Constructor signature audit

- README API reference: added `allow_http=False, discovery=None` to both `BlestaRequest` and `AsyncBlestaRequest` signatures.
- Fixed `generate_capabilities_report(format=...` → `output_format=...` in README and SDK_USAGE.md (wrong keyword arg in two places).
- SDK_USAGE.md async constructor section: added `allow_http` and `discovery` params with accurate comments.

## Checks

- black --check: passed (27 files unchanged)
- ruff check: passed
- pytest -q -m "not integration": 745 passed, 1 deselected

🤖 Generated with [Claude Code](https://claude.com/claude-code)