### PR TITLE
ci: expand matrix and add release validation gates

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,14 +8,41 @@ permissions:
   contents: read
 
 jobs:
+  test:
+    name: Test gate
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.13"]
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5.3.0
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install uv
+        run: pip install uv
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Run tests
+        run: uv run pytest -v -m "not integration" --cov=blesta_sdk --cov-report=term-missing --cov-fail-under=97
+
   build:
     name: Build
     runs-on: ubuntu-latest
+    needs:
+      - test
+
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Set up Python 3.13
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5.3.0
         with:
           python-version: "3.13"
 
@@ -28,8 +55,11 @@ jobs:
         run: uv build
         working-directory: .
 
+      - name: Check dist
+        run: uvx twine check dist/*
+
       - name: Upload distributions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08  # v4.6.0
         with:
           name: release-dists
           path: dist/
@@ -44,13 +74,13 @@ jobs:
 
     steps:
       - name: Retrieve release distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444306234caa3a0b0ac79fec  # v4.1.8
         with:
           name: release-dists
           path: dist/
 
       - name: Set up Python 3.13
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5.3.0
         with:
           python-version: "3.13"
 

--- a/.github/workflows/schema-refresh.yml
+++ b/.github/workflows/schema-refresh.yml
@@ -13,10 +13,10 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5.3.0
         with:
           python-version: '3.12'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5.3.0
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
Fixes #54

## Changes

### test.yml
- Expands Python test matrix from 3.9/3.12/3.13 to the full **3.9 / 3.10 / 3.11 / 3.12 / 3.13** range, matching `requires-python = ">=3.9"` and all five version classifiers in `pyproject.toml`
- SHA-pins `actions/checkout` (v4.2.2: `11bd719`) and `actions/setup-python` (v5.3.0: `0b93645`)

### publish.yml
- Adds a **test gate** job (`test`) that runs the full pytest suite on 3.9 + 3.13 before the build job is allowed to proceed (`needs: [test]`)
- Adds a **`twine check dist/*`** step (via `uvx twine`) after `uv build` to validate sdist/wheel metadata before upload
- SHA-pins all four actions: `checkout`, `setup-python`, `upload-artifact` (v4.6.0: `65c4c4a`), `download-artifact` (v4.1.8: `fa0a91b`)

### schema-refresh.yml
- SHA-pins `actions/checkout` and `actions/setup-python` to the same SHAs as above
- No logic changes; permissions (`contents: write`, `pull-requests: write`) were already correct

## Checks
- `uv build`: success (dist/blesta_sdk-0.6.0.tar.gz + .whl)
- YAML syntax: all three workflows validated OK
- Tests: 745 passed, 1 deselected (integration skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)