### PR TITLE
perf(response): cache CSV detection

### DIFF
--- a/src/blesta_sdk/_response.py
+++ b/src/blesta_sdk/_response.py
@@ -42,6 +42,7 @@ class BlestaResponse:
         self._headers: Mapping[str, str] = headers or {}
         self._parsed: dict[str, Any] | object = _UNSET
         self._json_valid: bool | None = None
+        self._is_csv: bool | None = None
         self._csv_cache: list[dict[str, str]] | None | object = _UNSET
 
     def __repr__(self) -> str:
@@ -84,7 +85,17 @@ class BlestaResponse:
 
     @property
     def is_csv(self) -> bool:
-        """Returns True if the raw response appears to be CSV data."""
+        """Returns True if the raw response appears to be CSV data.
+
+        The result is cached after the first call; subsequent accesses return
+        the stored value without re-parsing the raw body.
+        """
+        if self._is_csv is None:
+            self._is_csv = self._compute_is_csv()
+        return self._is_csv
+
+    def _compute_is_csv(self) -> bool:
+        """Compute whether the raw response is CSV data (called at most once)."""
         if self._status_code != 200:
             return False
         if not self._raw or not self._raw.strip():
@@ -262,6 +273,9 @@ class BlestaResponse:
         """
         # Ensure caches are populated before discarding raw text.
         self._format_response()
+        # Populate is_csv cache (reads raw body via splitlines).
+        if self._is_csv is None:
+            self._is_csv = self._compute_is_csv()
         if self._csv_cache is _UNSET:
             # Populate csv_data cache (may set to None).
             _ = self.csv_data

--- a/tests/test_response_edge_cases.py
+++ b/tests/test_response_edge_cases.py
@@ -425,3 +425,75 @@ class TestBlesta200ValidationErrors:
         assert len(errs) == 2
         assert "email" in errs
         assert "first_name" in errs
+
+
+# --- is_csv caching (#46) ---
+
+
+class TestIsCsvCaching:
+    """is_csv result is computed once and cached; subsequent accesses are free."""
+
+    CSV_BODY = "id,name,email\n1,Alice,alice@example.com\n2,Bob,bob@example.com"
+    JSON_BODY = '{"response": [{"id": 1}]}'
+
+    def test_is_csv_correct_for_csv_response(self):
+        """CSV body at status 200 must return True."""
+        r = make_response(self.CSV_BODY, 200)
+        assert r.is_csv is True
+
+    def test_is_csv_correct_for_json_response(self):
+        """JSON body must return False."""
+        r = make_response(self.JSON_BODY, 200)
+        assert r.is_csv is False
+
+    def test_is_csv_cached_across_calls(self):
+        """_compute_is_csv must be called exactly once regardless of how many
+        times is_csv is accessed."""
+        r = make_response(self.CSV_BODY, 200)
+        # Cache starts empty.
+        assert r._is_csv is None
+        # First access triggers computation and stores the result.
+        result1 = r.is_csv
+        assert r._is_csv is not None
+        assert result1 is True
+        # Patch _compute_is_csv to detect any further calls.
+        with patch.object(
+            r, "_compute_is_csv", wraps=r._compute_is_csv
+        ) as mock_compute:
+            result2 = r.is_csv
+            result3 = r.is_csv
+            mock_compute.assert_not_called()
+        assert result2 is True
+        assert result3 is True
+
+    def test_is_csv_cached_false_result(self):
+        """Cache stores False correctly — not re-evaluated on subsequent calls."""
+        r = make_response(self.JSON_BODY, 200)
+        # Prime the cache.
+        assert r.is_csv is False
+        assert r._is_csv is False
+        with patch.object(
+            r, "_compute_is_csv", wraps=r._compute_is_csv
+        ) as mock_compute:
+            assert r.is_csv is False
+            mock_compute.assert_not_called()
+
+    def test_free_raw_does_not_break_is_csv(self):
+        """is_csv must return the correct value after free_raw() clears the body."""
+        r = make_response(self.CSV_BODY, 200)
+        # Access is_csv before freeing raw — primes the cache.
+        assert r.is_csv is True
+        r.free_raw()
+        # Raw is gone, but the cached result must still be correct.
+        assert r.raw == ""
+        assert r.is_csv is True
+
+    def test_free_raw_primes_is_csv_cache(self):
+        """free_raw() primes the is_csv cache even if is_csv was never accessed."""
+        r = make_response(self.CSV_BODY, 200)
+        assert r._is_csv is None  # not yet computed
+        r.free_raw()
+        # free_raw must have populated the cache.
+        assert r._is_csv is True
+        # And is_csv still works after raw is gone.
+        assert r.is_csv is True


### PR DESCRIPTION
## Summary

Fixes #46. `is_csv` previously re-ran `splitlines()` and the comma check on every access. On large CSV responses accessed multiple times (e.g. `is_csv` called in `csv_data`, `errors()`, `to_dataframe()`, and user code) this was wasteful.

## Changes

**`src/blesta_sdk/_response.py`**
- Added `self._is_csv: bool | None = None` sentinel in `__init__`
- Extracted detection logic to `_compute_is_csv()` private method  
- `is_csv` property now caches result in `_is_csv` on first call; all subsequent accesses return the stored value
- `free_raw()` explicitly primes the `_is_csv` cache before discarding raw text, so the cached result survives after `raw` is cleared

## Tests added (`TestIsCsvCaching` in `test_response_edge_cases.py`)

- `test_is_csv_correct_for_csv_response` — CSV body returns True
- `test_is_csv_correct_for_json_response` — JSON body returns False
- `test_is_csv_cached_across_calls` — verifies `_compute_is_csv` is not called after first access
- `test_is_csv_cached_false_result` — False is stored and not re-computed
- `test_free_raw_does_not_break_is_csv` — cached value survives `free_raw()`
- `test_free_raw_primes_is_csv_cache` — `free_raw()` primes cache even if `is_csv` was never accessed

## Results

- 751 passed, 1 deselected (integration)
- black: clean
- ruff: clean
- coverage: 97.11% (above 97% threshold)

🤖 Generated with [Claude Code](https://claude.com/claude-code)