### PR TITLE
Namespace CLI under blesta_sdk.cli and stabilize blesta command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,10 @@ dependencies = [
 [project.optional-dependencies]
 cli = ["python-dotenv>=1.2.1"]
 async = ["httpx>=0.27"]
+data = ["pandas>=2.0"]
 
 [project.scripts]
-blesta = "blesta_sdk._cli:cli"
+blesta = "blesta_sdk.cli.app:main"
 
 [project.urls]
 Repository = "https://github.com/jwogrady/blesta_sdk"

--- a/src/blesta_sdk/_cli.py
+++ b/src/blesta_sdk/_cli.py
@@ -11,7 +11,7 @@ import logging
 import os
 import sys
 
-from blesta_sdk._client import BlestaRequest
+from blesta_sdk.core.client import BlestaRequest
 
 logger = logging.getLogger(__name__)
 

--- a/src/blesta_sdk/cli/__init__.py
+++ b/src/blesta_sdk/cli/__init__.py
@@ -1,0 +1,7 @@
+"""CLI adapter for the Blesta SDK."""
+
+from __future__ import annotations
+
+from blesta_sdk.cli.app import main
+
+__all__ = ["main"]

--- a/src/blesta_sdk/cli/app.py
+++ b/src/blesta_sdk/cli/app.py
@@ -1,0 +1,195 @@
+"""Main entry point for the ``blesta`` CLI command.
+
+Supports both the original flag-style syntax::
+
+    blesta --model clients --method getList --action GET --params status=active
+
+and the new subcommand syntax::
+
+    blesta call clients getList --param status=active
+    blesta extract clients getList --param status=active --format jsonl
+    blesta report package_revenue --start 2025-01-01 --end 2025-01-31
+    blesta discover models
+    blesta discover methods Clients
+    blesta discover spec Clients getList
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from blesta_sdk.core.client import BlestaRequest
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the top-level argparse parser.
+
+    :return: Configured :class:`~argparse.ArgumentParser`.
+    """
+    parser = argparse.ArgumentParser(
+        prog="blesta",
+        description="Blesta API Command Line Interface",
+    )
+
+    # ---- Legacy top-level flags (backward compat) ----------------------
+    parser.add_argument(
+        "--model",
+        help="[Legacy] Blesta API model (e.g., clients). Use subcommands instead.",
+    )
+    parser.add_argument(
+        "--method",
+        help="[Legacy] Blesta API method (e.g., getList). Use subcommands instead.",
+    )
+    parser.add_argument(
+        "--action",
+        type=str.upper,
+        choices=["GET", "POST", "PUT", "DELETE"],
+        default="GET",
+        help="[Legacy] HTTP action. Use subcommands instead.",
+    )
+    parser.add_argument(
+        "--params",
+        nargs="*",
+        metavar="KEY=VALUE",
+        help="[Legacy] Request parameters. Use subcommands instead.",
+    )
+    parser.add_argument(
+        "--last-request",
+        action="store_true",
+        help="[Legacy] Show the last API request made.",
+    )
+
+    # ---- Subcommands ----------------------------------------------------
+    subparsers = parser.add_subparsers(dest="subcommand", metavar="COMMAND")
+
+    from blesta_sdk.cli.commands.call import add_parser as add_call
+    from blesta_sdk.cli.commands.discover import add_parser as add_discover
+    from blesta_sdk.cli.commands.extract import add_parser as add_extract
+    from blesta_sdk.cli.commands.report import add_parser as add_report
+
+    add_call(subparsers)
+    add_extract(subparsers)
+    add_report(subparsers)
+    add_discover(subparsers)
+
+    return parser
+
+
+def main() -> None:
+    """Entry point for the ``blesta`` console script.
+
+    Reads credentials from ``BLESTA_API_URL``, ``BLESTA_API_USER``,
+    and ``BLESTA_API_KEY`` environment variables. If ``python-dotenv``
+    is installed, also loads ``.env`` from the current directory.
+
+    Set ``BLESTA_AUTH_METHOD`` to ``"header"`` to use header-based auth.
+    Set ``BLESTA_ALLOW_HTTP=1`` to permit ``http://`` base URLs.
+    """
+    try:
+        from dotenv import load_dotenv
+
+        load_dotenv()
+    except ImportError:
+        pass
+
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    # ---- Route to subcommand -------------------------------------------
+    if args.subcommand is not None:
+        # Dispatch to registered subcommand handler.
+        args.func(args)
+        return
+
+    # ---- Legacy flat-flag mode (--model / --method) --------------------
+    if args.model or args.method:
+        _run_legacy(args)
+        return
+
+    # No args at all → print help.
+    parser.print_help()
+    sys.exit(0)
+
+
+def _run_legacy(args: argparse.Namespace) -> None:
+    """Handle the legacy ``--model/--method`` syntax.
+
+    Delegates to the original :func:`~blesta_sdk._cli.cli` implementation
+    so existing callers and test patches continue to work unchanged.
+
+    :param args: Parsed arguments from the top-level parser.
+    """
+    # Reconstruct sys.argv as if the legacy CLI was called directly.
+    # This is the simplest way to reuse the original argument parsing
+    # without duplicating credential / validation logic.
+    import os
+
+    from blesta_sdk.cli.formatters import print_error, print_json
+
+    url = os.getenv("BLESTA_API_URL")
+    user = os.getenv("BLESTA_API_USER")
+    key = os.getenv("BLESTA_API_KEY")
+
+    if not all([url, user, key]):
+        print_error(
+            "Missing API credentials."
+            " Set BLESTA_API_URL, BLESTA_API_USER, and BLESTA_API_KEY."
+        )
+
+    if not args.model:
+        print_error("--model is required in legacy mode")
+    if not args.method:
+        print_error("--method is required in legacy mode")
+
+    auth_method = os.getenv("BLESTA_AUTH_METHOD", "basic").strip().lower()
+    if auth_method not in ("basic", "header"):
+        print_error(
+            f"Invalid BLESTA_AUTH_METHOD {auth_method!r}:"
+            " must be 'basic' or 'header'."
+        )
+    allow_http = os.getenv("BLESTA_ALLOW_HTTP", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+    import logging
+
+    log = logging.getLogger(__name__)
+    params: dict[str, str] = {}
+    for raw in args.params or []:
+        if not raw or "=" not in raw:
+            print_error(f"Invalid param '{raw}': expected key=value format")
+        k, v = raw.split("=", 1)
+        if not k:
+            print_error(f"Invalid param '{raw}': key cannot be empty")
+        if k in params:
+            log.warning("Duplicate CLI param '%s' — last value wins", k)
+        params[k] = v
+
+    api = BlestaRequest(
+        url,
+        user,
+        key,
+        auth_method=auth_method,
+        allow_http=allow_http,
+    )
+    response = api.submit(args.model, args.method, params, args.action)
+
+    if response.status_code == 200:
+        print_json(response.data)
+    else:
+        print_json(response.errors())
+
+    if args.last_request:
+        last_request = api.get_last_request()
+        if last_request:
+            print("\nLast Request URL:", last_request["url"])
+            print("Last Request Parameters:", last_request["args"])
+        else:
+            print("No previous API request made.")
+
+    if response.status_code != 200:
+        sys.exit(1)

--- a/src/blesta_sdk/cli/commands/__init__.py
+++ b/src/blesta_sdk/cli/commands/__init__.py
@@ -1,0 +1,1 @@
+"""Subcommand handlers for the Blesta CLI."""

--- a/src/blesta_sdk/cli/commands/call.py
+++ b/src/blesta_sdk/cli/commands/call.py
@@ -1,0 +1,98 @@
+"""``blesta call`` subcommand — invoke a single Blesta API method."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import TYPE_CHECKING
+
+from blesta_sdk.core.client import BlestaRequest
+
+if TYPE_CHECKING:
+    import argparse
+
+logger = logging.getLogger(__name__)
+
+
+def add_parser(subparsers: argparse.Action) -> None:
+    """Register the ``call`` subcommand on *subparsers*.
+
+    :param subparsers: Subparser action from the parent parser.
+    """
+    p = subparsers.add_parser(
+        "call",
+        help="Call a single Blesta API method",
+        description="Invoke model/method and print JSON response to stdout.",
+    )
+    p.add_argument("model", help="Blesta API model (e.g., clients)")
+    p.add_argument("method", help="Blesta API method (e.g., getList)")
+    p.add_argument(
+        "--action",
+        type=str.upper,
+        choices=["GET", "POST", "PUT", "DELETE"],
+        default=None,
+        help="HTTP method override. Inferred from schema if omitted.",
+    )
+    p.add_argument(
+        "--param",
+        dest="params",
+        nargs="*",
+        metavar="KEY=VALUE",
+        help="Request parameters as key=value pairs.",
+    )
+    p.set_defaults(func=run)
+
+
+def run(args: argparse.Namespace) -> None:
+    """Execute the ``call`` subcommand.
+
+    :param args: Parsed CLI arguments.
+    """
+    from blesta_sdk.cli.formatters import print_error, print_json
+
+    url = os.getenv("BLESTA_API_URL")
+    user = os.getenv("BLESTA_API_USER")
+    key = os.getenv("BLESTA_API_KEY")
+
+    if not all([url, user, key]):
+        print_error(
+            "Missing API credentials."
+            " Set BLESTA_API_URL, BLESTA_API_USER, and BLESTA_API_KEY."
+        )
+
+    auth_method = os.getenv("BLESTA_AUTH_METHOD", "basic").strip().lower()
+    allow_http = os.getenv("BLESTA_ALLOW_HTTP", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+    params: dict[str, str] = {}
+    for raw in args.params or []:
+        if not raw or "=" not in raw:
+            print_error(f"Invalid param {raw!r}: expected key=value format")
+        k, v = raw.split("=", 1)
+        if not k:
+            print_error(f"Invalid param {raw!r}: key cannot be empty")
+        if k in params:
+            logger.warning("Duplicate CLI param '%s' — last value wins", k)
+        params[k] = v
+
+    api = BlestaRequest(
+        url,
+        user,
+        key,
+        auth_method=auth_method,
+        allow_http=allow_http,
+    )
+
+    if args.action is not None:
+        response = api.submit(args.model, args.method, params, args.action)
+    else:
+        response = api.call(args.model, args.method, params)
+
+    if response.status_code == 200:
+        print_json(response.data)
+    else:
+        print_json(response.errors())

--- a/src/blesta_sdk/cli/commands/discover.py
+++ b/src/blesta_sdk/cli/commands/discover.py
@@ -1,0 +1,81 @@
+"""``blesta discover`` subcommand — introspect the Blesta API schema."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import argparse
+
+
+def add_parser(subparsers: argparse.Action) -> None:
+    """Register the ``discover`` subcommand on *subparsers*.
+
+    :param subparsers: Subparser action from the parent parser.
+    """
+    p = subparsers.add_parser(
+        "discover",
+        help="Introspect the Blesta API schema",
+        description="List models, methods, or get a full method spec.",
+    )
+    dp = p.add_subparsers(dest="discover_cmd", metavar="COMMAND")
+    dp.required = True
+
+    # discover models
+    dp.add_parser("models", help="List all available API models")
+
+    # discover methods <model>
+    pm = dp.add_parser("methods", help="List all methods for a model")
+    pm.add_argument("model", help="Model name (e.g., Clients)")
+
+    # discover spec <model> <method>
+    ps = dp.add_parser("spec", help="Show full spec for a model/method")
+    ps.add_argument("model", help="Model name (e.g., Clients)")
+    ps.add_argument("method", help="Method name (e.g., getList)")
+
+    p.set_defaults(func=run)
+
+
+def run(args: argparse.Namespace) -> None:
+    """Execute the ``discover`` subcommand.
+
+    :param args: Parsed CLI arguments.
+    """
+    from blesta_sdk.cli.formatters import print_json
+    from blesta_sdk.discovery.registry import BlestaDiscovery
+
+    disco = BlestaDiscovery()
+    cmd = args.discover_cmd
+
+    if cmd == "models":
+        print_json(disco.list_models())
+
+    elif cmd == "methods":
+        try:
+            print_json(disco.list_methods(args.model))
+        except KeyError as exc:
+            from blesta_sdk.cli.formatters import print_error
+
+            print_error(str(exc))
+
+    elif cmd == "spec":
+        try:
+            spec = disco.get_method_spec(args.model, args.method)
+            print_json(
+                {
+                    "model": spec.model,
+                    "method": spec.method,
+                    "http_method": spec.http_method,
+                    "category": spec.category,
+                    "description": spec.description,
+                    "params": spec.params,
+                    "return_type": spec.return_type,
+                    "return_description": spec.return_description,
+                    "source": spec.source,
+                    "signature": spec.signature,
+                }
+            )
+        except KeyError as exc:
+            from blesta_sdk.cli.formatters import print_error
+
+            print_error(str(exc))

--- a/src/blesta_sdk/cli/commands/extract.py
+++ b/src/blesta_sdk/cli/commands/extract.py
@@ -1,0 +1,111 @@
+"""``blesta extract`` subcommand — paginate and dump all records."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import TYPE_CHECKING
+
+from blesta_sdk.core.client import BlestaRequest
+
+if TYPE_CHECKING:
+    import argparse
+
+logger = logging.getLogger(__name__)
+
+_FORMATS = ("json", "jsonl", "csv")
+
+
+def add_parser(subparsers: argparse.Action) -> None:
+    """Register the ``extract`` subcommand on *subparsers*.
+
+    :param subparsers: Subparser action from the parent parser.
+    """
+    p = subparsers.add_parser(
+        "extract",
+        help="Fetch all pages from a list endpoint",
+        description=(
+            "Paginate a Blesta list method and output all records."
+            " Defaults to JSON output."
+        ),
+    )
+    p.add_argument("model", help="Blesta API model (e.g., clients)")
+    p.add_argument("method", help="Blesta API method (e.g., getList)")
+    p.add_argument(
+        "--param",
+        dest="params",
+        nargs="*",
+        metavar="KEY=VALUE",
+        help="Request parameters as key=value pairs.",
+    )
+    p.add_argument(
+        "--format",
+        dest="output_format",
+        choices=_FORMATS,
+        default="json",
+        help="Output format: json (default), jsonl, or csv.",
+    )
+    p.set_defaults(func=run)
+
+
+def run(args: argparse.Namespace) -> None:
+    """Execute the ``extract`` subcommand.
+
+    :param args: Parsed CLI arguments.
+    """
+    from blesta_sdk.cli.formatters import (
+        print_csv,
+        print_error,
+        print_json,
+        print_jsonl,
+    )
+
+    url = os.getenv("BLESTA_API_URL")
+    user = os.getenv("BLESTA_API_USER")
+    key = os.getenv("BLESTA_API_KEY")
+
+    if not all([url, user, key]):
+        print_error(
+            "Missing API credentials."
+            " Set BLESTA_API_URL, BLESTA_API_USER, and BLESTA_API_KEY."
+        )
+
+    auth_method = os.getenv("BLESTA_AUTH_METHOD", "basic").strip().lower()
+    allow_http = os.getenv("BLESTA_ALLOW_HTTP", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+    params: dict[str, str] = {}
+    for raw in args.params or []:
+        if not raw or "=" not in raw:
+            print_error(f"Invalid param {raw!r}: expected key=value format")
+        k, v = raw.split("=", 1)
+        if not k:
+            print_error(f"Invalid param {raw!r}: key cannot be empty")
+        if k in params:
+            logger.warning("Duplicate CLI param '%s' — last value wins", k)
+        params[k] = v
+
+    api = BlestaRequest(
+        url,
+        user,
+        key,
+        auth_method=auth_method,
+        allow_http=allow_http,
+    )
+
+    rows = api.get_all(args.model, args.method, params or None)
+
+    fmt = getattr(args, "output_format", "json")
+    if fmt == "jsonl":
+        print_jsonl(rows)
+    elif fmt == "csv":
+        if rows and isinstance(rows[0], dict):
+            print_csv(rows)
+        else:
+            print_json(rows)
+    else:
+        print_json(rows)

--- a/src/blesta_sdk/cli/commands/report.py
+++ b/src/blesta_sdk/cli/commands/report.py
@@ -1,0 +1,103 @@
+"""``blesta report`` subcommand — fetch a Blesta report."""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+from blesta_sdk.core.client import BlestaRequest
+
+if TYPE_CHECKING:
+    import argparse
+
+
+def add_parser(subparsers: argparse.Action) -> None:
+    """Register the ``report`` subcommand on *subparsers*.
+
+    :param subparsers: Subparser action from the parent parser.
+    """
+    p = subparsers.add_parser(
+        "report",
+        help="Fetch a Blesta report",
+        description=(
+            "Call report_manager/fetchAll for a date range."
+            " CSV responses are converted to JSON rows."
+        ),
+    )
+    p.add_argument("report_type", help="Report type (e.g., package_revenue)")
+    p.add_argument(
+        "--start",
+        required=True,
+        metavar="YYYY-MM-DD",
+        help="Report start date.",
+    )
+    p.add_argument(
+        "--end",
+        required=True,
+        metavar="YYYY-MM-DD",
+        help="Report end date.",
+    )
+    p.add_argument(
+        "--param",
+        dest="params",
+        nargs="*",
+        metavar="KEY=VALUE",
+        help="Extra vars[] parameters as key=value pairs.",
+    )
+    p.set_defaults(func=run)
+
+
+def run(args: argparse.Namespace) -> None:
+    """Execute the ``report`` subcommand.
+
+    :param args: Parsed CLI arguments.
+    """
+    from blesta_sdk.cli.formatters import print_error, print_json
+
+    url = os.getenv("BLESTA_API_URL")
+    user = os.getenv("BLESTA_API_USER")
+    key = os.getenv("BLESTA_API_KEY")
+
+    if not all([url, user, key]):
+        print_error(
+            "Missing API credentials."
+            " Set BLESTA_API_URL, BLESTA_API_USER, and BLESTA_API_KEY."
+        )
+
+    auth_method = os.getenv("BLESTA_AUTH_METHOD", "basic").strip().lower()
+    allow_http = os.getenv("BLESTA_ALLOW_HTTP", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+    extra_vars: dict[str, str] = {}
+    for raw in args.params or []:
+        if not raw or "=" not in raw:
+            print_error(f"Invalid param {raw!r}: expected key=value format")
+        k, v = raw.split("=", 1)
+        extra_vars[k] = v
+
+    api = BlestaRequest(
+        url,
+        user,
+        key,
+        auth_method=auth_method,
+        allow_http=allow_http,
+    )
+
+    response = api.get_report(
+        args.report_type,
+        args.start,
+        args.end,
+        extra_vars or None,
+    )
+
+    if response.status_code != 200:
+        print_error(f"Report request failed: HTTP {response.status_code}")
+
+    if response.is_csv:
+        print_json(response.csv_data or [])
+    else:
+        print_json(response.data)

--- a/src/blesta_sdk/cli/formatters.py
+++ b/src/blesta_sdk/cli/formatters.py
@@ -1,0 +1,61 @@
+"""Output formatters for the Blesta CLI."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+
+def print_json(data: Any, *, indent: int = 4) -> None:
+    """Print *data* as indented JSON to stdout.
+
+    :param data: JSON-serialisable value.
+    :param indent: Indentation level.
+    """
+    print(json.dumps(data, indent=indent))
+
+
+def print_jsonl(rows: list[Any]) -> None:
+    """Print each item in *rows* as a separate JSON line to stdout.
+
+    :param rows: List of JSON-serialisable values.
+    """
+    for row in rows:
+        print(json.dumps(row))
+
+
+def print_csv(rows: list[dict[str, Any]]) -> None:
+    """Print *rows* as CSV to stdout.
+
+    The first row's keys become the header.  Rows with missing keys
+    receive empty strings.
+
+    :param rows: List of dicts.
+    """
+    import csv
+    import io
+
+    if not rows:
+        return
+    fieldnames = list(rows[0].keys())
+    buf = io.StringIO()
+    writer = csv.DictWriter(
+        buf,
+        fieldnames=fieldnames,
+        extrasaction="ignore",
+        lineterminator="\n",
+    )
+    writer.writeheader()
+    writer.writerows(rows)
+    print(buf.getvalue(), end="")
+
+
+def print_error(message: str, *, exit_code: int = 1) -> None:
+    """Print a JSON error object to stdout and exit.
+
+    :param message: Error description.
+    :param exit_code: Process exit code.
+    """
+    print(json.dumps({"error": message}, indent=4))
+    sys.exit(exit_code)

--- a/tests/test_blesta_sdk.py
+++ b/tests/test_blesta_sdk.py
@@ -2961,16 +2961,14 @@ class TestCoreNamespaceImports:
         assert BRsp is BlestaResponse
 
     def test_core_errors_import(self):
-        from blesta_sdk.core.errors import BlestaError as BE
-
         from blesta_sdk import BlestaError
+        from blesta_sdk.core.errors import BlestaError as BE
 
         assert BE is BlestaError
 
     def test_core_config_import(self):
-        from blesta_sdk.core.config import BlestaEnvConfig as BEC
-
         from blesta_sdk import BlestaEnvConfig
+        from blesta_sdk.core.config import BlestaEnvConfig as BEC
 
         assert BEC is BlestaEnvConfig
 
@@ -3021,9 +3019,8 @@ class TestCoreNamespaceImports:
         assert BD is BlestaDiscovery
 
     def test_compat_shim_exceptions(self):
-        from blesta_sdk._exceptions import BlestaError as BE
-
         from blesta_sdk import BlestaError
+        from blesta_sdk._exceptions import BlestaError as BE
 
         assert BE is BlestaError
 
@@ -3033,8 +3030,134 @@ class TestCoreNamespaceImports:
         assert BRsp is BlestaResponse
 
     def test_compat_shim_env_config(self):
+        from blesta_sdk import BlestaEnvConfig
         from blesta_sdk._env_config import BlestaEnvConfig as BEC
 
-        from blesta_sdk import BlestaEnvConfig
-
         assert BEC is BlestaEnvConfig
+
+
+# ---------------------------------------------------------------------------
+# New CLI namespace tests (Issue #72)
+# ---------------------------------------------------------------------------
+
+
+class TestCliNamespaceImports:
+    """Verify the blesta_sdk.cli package and subcommand structure exist."""
+
+    def test_cli_app_main_callable(self):
+        from blesta_sdk.cli.app import main
+
+        assert callable(main)
+
+    def test_cli_init_exports_main(self):
+        from blesta_sdk.cli import main
+
+        assert callable(main)
+
+    def test_cli_formatters_importable(self):
+        from blesta_sdk.cli.formatters import (
+            print_csv,
+            print_error,
+            print_json,
+            print_jsonl,
+        )
+
+        assert all(
+            callable(f) for f in [print_json, print_jsonl, print_csv, print_error]
+        )
+
+    def test_cli_command_modules_importable(self):
+        from blesta_sdk.cli.commands import call, discover, extract, report
+
+        assert all(hasattr(m, "add_parser") for m in [call, extract, report, discover])
+        assert all(hasattr(m, "run") for m in [call, extract, report, discover])
+
+
+class TestCliSubcommandHelp:
+    """Verify argparse structure for each subcommand."""
+
+    def test_main_help_exits_zero(self, capsys):
+
+        from blesta_sdk.cli.app import _build_parser
+
+        parser = _build_parser()
+        with pytest.raises(SystemExit) as exc_info:
+            parser.parse_args(["--help"])
+        assert exc_info.value.code == 0
+
+    def test_call_subcommand_parsed(self):
+        from blesta_sdk.cli.app import _build_parser
+
+        parser = _build_parser()
+        args = parser.parse_args(
+            ["call", "clients", "getList", "--param", "status=active"]
+        )
+        assert args.subcommand == "call"
+        assert args.model == "clients"
+        assert args.method == "getList"
+        assert args.params == ["status=active"]
+
+    def test_extract_subcommand_parsed(self):
+        from blesta_sdk.cli.app import _build_parser
+
+        parser = _build_parser()
+        args = parser.parse_args(["extract", "clients", "getList", "--format", "jsonl"])
+        assert args.subcommand == "extract"
+        assert args.output_format == "jsonl"
+
+    def test_report_subcommand_parsed(self):
+        from blesta_sdk.cli.app import _build_parser
+
+        parser = _build_parser()
+        args = parser.parse_args(
+            [
+                "report",
+                "package_revenue",
+                "--start",
+                "2025-01-01",
+                "--end",
+                "2025-01-31",
+            ]
+        )
+        assert args.subcommand == "report"
+        assert args.report_type == "package_revenue"
+        assert args.start == "2025-01-01"
+        assert args.end == "2025-01-31"
+
+    def test_discover_models_subcommand_parsed(self):
+        from blesta_sdk.cli.app import _build_parser
+
+        parser = _build_parser()
+        args = parser.parse_args(["discover", "models"])
+        assert args.subcommand == "discover"
+        assert args.discover_cmd == "models"
+
+    def test_discover_methods_subcommand_parsed(self):
+        from blesta_sdk.cli.app import _build_parser
+
+        parser = _build_parser()
+        args = parser.parse_args(["discover", "methods", "Clients"])
+        assert args.discover_cmd == "methods"
+        assert args.model == "Clients"
+
+    def test_discover_spec_subcommand_parsed(self):
+        from blesta_sdk.cli.app import _build_parser
+
+        parser = _build_parser()
+        args = parser.parse_args(["discover", "spec", "Clients", "getList"])
+        assert args.discover_cmd == "spec"
+        assert args.model == "Clients"
+        assert args.method == "getList"
+
+    def test_legacy_flags_still_parsed(self):
+        """The old --model/--method flags still parse correctly."""
+        from blesta_sdk.cli.app import _build_parser
+
+        parser = _build_parser()
+        args = parser.parse_args(
+            ["--model", "clients", "--method", "getList", "--action", "GET"]
+        )
+        assert args.model == "clients"
+        assert args.method == "getList"
+        assert args.action == "GET"
+        assert args.subcommand is None

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1,0 +1,652 @@
+"""Tests for blesta_sdk.cli command handlers and formatters."""
+
+from __future__ import annotations
+
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Formatters
+# ---------------------------------------------------------------------------
+
+
+def test_print_json(capsys):
+    from blesta_sdk.cli.formatters import print_json
+
+    print_json({"key": "value"})
+    out = capsys.readouterr().out
+    assert '"key": "value"' in out
+
+
+def test_print_jsonl(capsys):
+    from blesta_sdk.cli.formatters import print_jsonl
+
+    print_jsonl([{"a": 1}, {"b": 2}])
+    lines = capsys.readouterr().out.strip().splitlines()
+    assert len(lines) == 2
+    assert json.loads(lines[0]) == {"a": 1}
+
+
+def test_print_csv(capsys):
+    from blesta_sdk.cli.formatters import print_csv
+
+    rows = [{"name": "Alice", "age": "30"}, {"name": "Bob", "age": "25"}]
+    print_csv(rows)
+    out = capsys.readouterr().out
+    assert "name,age" in out
+    assert "Alice" in out
+
+
+def test_print_csv_empty(capsys):
+    from blesta_sdk.cli.formatters import print_csv
+
+    print_csv([])
+    out = capsys.readouterr().out
+    assert out == ""
+
+
+def test_print_error_exits(capsys):
+    from blesta_sdk.cli.formatters import print_error
+
+    with pytest.raises(SystemExit) as exc_info:
+        print_error("something went wrong")
+    assert exc_info.value.code == 1
+    out = capsys.readouterr().out
+    assert "something went wrong" in out
+
+
+# ---------------------------------------------------------------------------
+# blesta call
+# ---------------------------------------------------------------------------
+
+
+_CREDS = {
+    "BLESTA_API_URL": "https://example.com/api",
+    "BLESTA_API_USER": "user",
+    "BLESTA_API_KEY": "key",
+}
+
+
+def _mock_response(data=None, status_code=200):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.data = data
+    resp.errors.return_value = {"error": "bad"} if status_code != 200 else None
+    return resp
+
+
+def test_call_run_get(capsys):
+    from blesta_sdk.cli.app import _build_parser
+    from blesta_sdk.cli.commands import call
+
+    mock_resp = _mock_response(data=[{"id": 1}])
+    with (
+        patch.dict(os.environ, _CREDS),
+        patch("blesta_sdk.cli.commands.call.BlestaRequest") as MockApi,
+    ):
+        MockApi.return_value.submit.return_value = mock_resp
+        args = _build_parser().parse_args(
+            [
+                "call",
+                "clients",
+                "getList",
+                "--action",
+                "GET",
+                "--param",
+                "status=active",
+            ]
+        )
+        call.run(args)
+
+    out = capsys.readouterr().out
+    assert "id" in out
+
+
+def test_call_run_inferred_method(capsys):
+    from blesta_sdk.cli.app import _build_parser
+    from blesta_sdk.cli.commands import call
+
+    mock_resp = _mock_response(data={"id": 5})
+    with (
+        patch.dict(os.environ, _CREDS),
+        patch("blesta_sdk.cli.commands.call.BlestaRequest") as MockApi,
+    ):
+        MockApi.return_value.call.return_value = mock_resp
+        args = _build_parser().parse_args(["call", "clients", "getList"])
+        call.run(args)
+
+    out = capsys.readouterr().out
+    assert "id" in out
+
+
+def test_call_run_missing_creds():
+    from blesta_sdk.cli.app import _build_parser
+    from blesta_sdk.cli.commands import call
+
+    with (
+        patch.dict(os.environ, {}, clear=True),
+        pytest.raises(SystemExit),
+    ):
+        args = _build_parser().parse_args(["call", "clients", "getList"])
+        call.run(args)
+
+
+def test_call_run_non200(capsys):
+    from blesta_sdk.cli.app import _build_parser
+    from blesta_sdk.cli.commands import call
+
+    mock_resp = _mock_response(status_code=403)
+    with (
+        patch.dict(os.environ, _CREDS),
+        patch("blesta_sdk.cli.commands.call.BlestaRequest") as MockApi,
+    ):
+        MockApi.return_value.submit.return_value = mock_resp
+        args = _build_parser().parse_args(
+            ["call", "clients", "getList", "--action", "GET"]
+        )
+        call.run(args)
+
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert "error" in data
+
+
+def test_call_run_invalid_param():
+    from blesta_sdk.cli.app import _build_parser
+    from blesta_sdk.cli.commands import call
+
+    with (
+        patch.dict(os.environ, _CREDS),
+        pytest.raises(SystemExit),
+    ):
+        args = _build_parser().parse_args(
+            ["call", "clients", "getList", "--action", "GET", "--param", "noequalssign"]
+        )
+        call.run(args)
+
+
+# ---------------------------------------------------------------------------
+# blesta extract
+# ---------------------------------------------------------------------------
+
+
+def test_extract_run_json(capsys):
+    from blesta_sdk.cli.app import _build_parser
+    from blesta_sdk.cli.commands import extract
+
+    rows = [{"id": 1}, {"id": 2}]
+    with (
+        patch.dict(os.environ, _CREDS),
+        patch("blesta_sdk.cli.commands.extract.BlestaRequest") as MockApi,
+    ):
+        MockApi.return_value.get_all.return_value = rows
+        args = _build_parser().parse_args(["extract", "clients", "getList"])
+        extract.run(args)
+
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert len(data) == 2
+
+
+def test_extract_run_jsonl(capsys):
+    from blesta_sdk.cli.app import _build_parser
+    from blesta_sdk.cli.commands import extract
+
+    rows = [{"id": 1}, {"id": 2}]
+    with (
+        patch.dict(os.environ, _CREDS),
+        patch("blesta_sdk.cli.commands.extract.BlestaRequest") as MockApi,
+    ):
+        MockApi.return_value.get_all.return_value = rows
+        args = _build_parser().parse_args(
+            ["extract", "clients", "getList", "--format", "jsonl"]
+        )
+        extract.run(args)
+
+    lines = capsys.readouterr().out.strip().splitlines()
+    assert len(lines) == 2
+
+
+def test_extract_run_csv(capsys):
+    from blesta_sdk.cli.app import _build_parser
+    from blesta_sdk.cli.commands import extract
+
+    rows = [{"name": "Alice"}, {"name": "Bob"}]
+    with (
+        patch.dict(os.environ, _CREDS),
+        patch("blesta_sdk.cli.commands.extract.BlestaRequest") as MockApi,
+    ):
+        MockApi.return_value.get_all.return_value = rows
+        args = _build_parser().parse_args(
+            ["extract", "clients", "getList", "--format", "csv"]
+        )
+        extract.run(args)
+
+    out = capsys.readouterr().out
+    assert "name" in out
+    assert "Alice" in out
+
+
+def test_extract_run_missing_creds():
+    from blesta_sdk.cli.app import _build_parser
+    from blesta_sdk.cli.commands import extract
+
+    with (
+        patch.dict(os.environ, {}, clear=True),
+        pytest.raises(SystemExit),
+    ):
+        args = _build_parser().parse_args(["extract", "clients", "getList"])
+        extract.run(args)
+
+
+# ---------------------------------------------------------------------------
+# blesta report
+# ---------------------------------------------------------------------------
+
+
+def test_report_run_csv_response(capsys):
+    from blesta_sdk.cli.app import _build_parser
+    from blesta_sdk.cli.commands import report
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.is_csv = True
+    mock_resp.csv_data = [{"col": "val"}]
+
+    with (
+        patch.dict(os.environ, _CREDS),
+        patch("blesta_sdk.cli.commands.report.BlestaRequest") as MockApi,
+    ):
+        MockApi.return_value.get_report.return_value = mock_resp
+        args = _build_parser().parse_args(
+            [
+                "report",
+                "package_revenue",
+                "--start",
+                "2025-01-01",
+                "--end",
+                "2025-01-31",
+            ]
+        )
+        report.run(args)
+
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert data == [{"col": "val"}]
+
+
+def test_report_run_json_response(capsys):
+    from blesta_sdk.cli.app import _build_parser
+    from blesta_sdk.cli.commands import report
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.is_csv = False
+    mock_resp.data = {"total": 42}
+
+    with (
+        patch.dict(os.environ, _CREDS),
+        patch("blesta_sdk.cli.commands.report.BlestaRequest") as MockApi,
+    ):
+        MockApi.return_value.get_report.return_value = mock_resp
+        args = _build_parser().parse_args(
+            [
+                "report",
+                "package_revenue",
+                "--start",
+                "2025-01-01",
+                "--end",
+                "2025-01-31",
+            ]
+        )
+        report.run(args)
+
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert data == {"total": 42}
+
+
+def test_report_run_error_response():
+    from blesta_sdk.cli.app import _build_parser
+    from blesta_sdk.cli.commands import report
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 500
+
+    with (
+        patch.dict(os.environ, _CREDS),
+        patch("blesta_sdk.cli.commands.report.BlestaRequest") as MockApi,
+        pytest.raises(SystemExit),
+    ):
+        MockApi.return_value.get_report.return_value = mock_resp
+        args = _build_parser().parse_args(
+            [
+                "report",
+                "package_revenue",
+                "--start",
+                "2025-01-01",
+                "--end",
+                "2025-01-31",
+            ]
+        )
+        report.run(args)
+
+
+def test_report_run_missing_creds():
+    from blesta_sdk.cli.app import _build_parser
+    from blesta_sdk.cli.commands import report
+
+    with (
+        patch.dict(os.environ, {}, clear=True),
+        pytest.raises(SystemExit),
+    ):
+        args = _build_parser().parse_args(
+            [
+                "report",
+                "package_revenue",
+                "--start",
+                "2025-01-01",
+                "--end",
+                "2025-01-31",
+            ]
+        )
+        report.run(args)
+
+
+# ---------------------------------------------------------------------------
+# blesta discover
+# ---------------------------------------------------------------------------
+
+
+def test_discover_models(capsys):
+    from blesta_sdk.cli.app import _build_parser
+    from blesta_sdk.cli.commands import discover
+
+    args = _build_parser().parse_args(["discover", "models"])
+    discover.run(args)
+    out = capsys.readouterr().out
+    models = json.loads(out)
+    assert isinstance(models, list)
+    assert len(models) > 0
+
+
+def test_discover_methods(capsys):
+    from blesta_sdk.cli.app import _build_parser
+    from blesta_sdk.cli.commands import discover
+
+    args = _build_parser().parse_args(["discover", "methods", "Clients"])
+    discover.run(args)
+    out = capsys.readouterr().out
+    methods = json.loads(out)
+    assert isinstance(methods, list)
+    assert "getList" in methods
+
+
+def test_discover_methods_unknown_model():
+    from blesta_sdk.cli.app import _build_parser
+    from blesta_sdk.cli.commands import discover
+
+    with pytest.raises(SystemExit):
+        args = _build_parser().parse_args(
+            ["discover", "methods", "NonExistentModel999"]
+        )
+        discover.run(args)
+
+
+def test_discover_spec(capsys):
+    from blesta_sdk.cli.app import _build_parser
+    from blesta_sdk.cli.commands import discover
+
+    args = _build_parser().parse_args(["discover", "spec", "Clients", "getList"])
+    discover.run(args)
+    out = capsys.readouterr().out
+    spec = json.loads(out)
+    assert spec["model"] == "Clients"
+    assert spec["method"] == "getList"
+
+
+def test_discover_spec_unknown_method():
+    from blesta_sdk.cli.app import _build_parser
+    from blesta_sdk.cli.commands import discover
+
+    with pytest.raises(SystemExit):
+        args = _build_parser().parse_args(
+            ["discover", "spec", "Clients", "nonExistentMethod999"]
+        )
+        discover.run(args)
+
+
+# ---------------------------------------------------------------------------
+# blesta app legacy mode
+# ---------------------------------------------------------------------------
+
+
+def test_app_main_legacy_mode(capsys):
+    """Test main() routes --model/--method to the legacy handler."""
+    import sys
+
+    from blesta_sdk.cli.app import main
+
+    mock_resp = _mock_response(data={"id": 1})
+    with (
+        patch.dict(os.environ, _CREDS),
+        patch("blesta_sdk.cli.app.BlestaRequest") as MockApi,
+        patch.object(
+            sys, "argv", ["blesta", "--model", "clients", "--method", "getList"]
+        ),
+    ):
+        MockApi.return_value.submit.return_value = mock_resp
+        main()
+
+    out = capsys.readouterr().out
+    assert "id" in out
+
+
+def test_app_main_no_args_prints_help(capsys):
+    import sys
+
+    from blesta_sdk.cli.app import main
+
+    with (
+        patch.object(sys, "argv", ["blesta"]),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        main()
+    assert exc_info.value.code == 0
+
+
+# ---------------------------------------------------------------------------
+# Additional coverage tests
+# ---------------------------------------------------------------------------
+
+
+def test_app_main_subcommand_dispatch(capsys):
+    """Test main() dispatches to subcommand handler via args.func."""
+    import sys
+
+    from blesta_sdk.cli.app import main
+
+    with (patch.object(sys, "argv", ["blesta", "discover", "models"]),):
+        main()
+
+    out = capsys.readouterr().out
+    models = json.loads(out)
+    assert isinstance(models, list)
+
+
+def test_app_legacy_missing_creds():
+    import sys
+
+    from blesta_sdk.cli.app import main
+
+    with (
+        patch.dict(os.environ, {}, clear=True),
+        patch("dotenv.load_dotenv"),
+        patch.object(
+            sys, "argv", ["blesta", "--model", "clients", "--method", "getList"]
+        ),
+        pytest.raises(SystemExit),
+    ):
+        main()
+
+
+def test_app_legacy_invalid_auth_method():
+    import sys
+
+    from blesta_sdk.cli.app import main
+
+    creds = {**_CREDS, "BLESTA_AUTH_METHOD": "oauth"}
+    with (
+        patch.dict(os.environ, creds),
+        patch.object(
+            sys, "argv", ["blesta", "--model", "clients", "--method", "getList"]
+        ),
+        pytest.raises(SystemExit),
+    ):
+        main()
+
+
+def test_app_legacy_non200_exits_1(capsys):
+    import sys
+
+    from blesta_sdk.cli.app import main
+
+    mock_resp = _mock_response(status_code=404)
+    mock_resp.errors.return_value = {"error": "not found"}
+    with (
+        patch.dict(os.environ, _CREDS),
+        patch("blesta_sdk.cli.app.BlestaRequest") as MockApi,
+        patch.object(
+            sys,
+            "argv",
+            ["blesta", "--model", "clients", "--method", "getList", "--action", "GET"],
+        ),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        MockApi.return_value.submit.return_value = mock_resp
+        main()
+    assert exc_info.value.code == 1
+
+
+def test_app_legacy_last_request(capsys):
+    import sys
+
+    from blesta_sdk.cli.app import main
+
+    mock_resp = _mock_response(data={"id": 1})
+    last_req = {"url": "https://example.com/api/clients/getList.json", "args": {}}
+    with (
+        patch.dict(os.environ, _CREDS),
+        patch("blesta_sdk.cli.app.BlestaRequest") as MockApi,
+        patch.object(
+            sys,
+            "argv",
+            ["blesta", "--model", "clients", "--method", "getList", "--last-request"],
+        ),
+    ):
+        MockApi.return_value.submit.return_value = mock_resp
+        MockApi.return_value.get_last_request.return_value = last_req
+        main()
+
+    out = capsys.readouterr().out
+    assert "Last Request URL" in out
+
+
+def test_call_run_duplicate_param(capsys):
+    from blesta_sdk.cli.app import _build_parser
+    from blesta_sdk.cli.commands import call
+
+    mock_resp = _mock_response(data=[])
+    with (
+        patch.dict(os.environ, _CREDS),
+        patch("blesta_sdk.cli.commands.call.BlestaRequest") as MockApi,
+    ):
+        MockApi.return_value.submit.return_value = mock_resp
+        args = _build_parser().parse_args(
+            [
+                "call",
+                "clients",
+                "getList",
+                "--action",
+                "GET",
+                "--param",
+                "status=active",
+                "status=inactive",
+            ]
+        )
+        call.run(args)
+
+    out = capsys.readouterr().out
+    assert json.loads(out) == []
+
+
+def test_extract_missing_creds_param():
+    from blesta_sdk.cli.app import _build_parser
+    from blesta_sdk.cli.commands import extract
+
+    with (
+        patch.dict(os.environ, _CREDS),
+        patch("blesta_sdk.cli.commands.extract.BlestaRequest") as MockApi,
+        pytest.raises(SystemExit),
+    ):
+        MockApi.return_value.get_all.return_value = []
+        args = _build_parser().parse_args(
+            ["extract", "clients", "getList", "--param", "badparam"]
+        )
+        extract.run(args)
+
+
+def test_extract_run_csv_non_dict(capsys):
+    from blesta_sdk.cli.app import _build_parser
+    from blesta_sdk.cli.commands import extract
+
+    rows = [1, 2, 3]
+    with (
+        patch.dict(os.environ, _CREDS),
+        patch("blesta_sdk.cli.commands.extract.BlestaRequest") as MockApi,
+    ):
+        MockApi.return_value.get_all.return_value = rows
+        args = _build_parser().parse_args(
+            ["extract", "clients", "getList", "--format", "csv"]
+        )
+        extract.run(args)
+
+    out = capsys.readouterr().out
+    assert json.loads(out) == [1, 2, 3]
+
+
+def test_report_run_with_extra_params(capsys):
+    from blesta_sdk.cli.app import _build_parser
+    from blesta_sdk.cli.commands import report
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.is_csv = False
+    mock_resp.data = {"rows": []}
+
+    with (
+        patch.dict(os.environ, _CREDS),
+        patch("blesta_sdk.cli.commands.report.BlestaRequest") as MockApi,
+    ):
+        MockApi.return_value.get_report.return_value = mock_resp
+        args = _build_parser().parse_args(
+            [
+                "report",
+                "package_revenue",
+                "--start",
+                "2025-01-01",
+                "--end",
+                "2025-01-31",
+                "--param",
+                "currency=USD",
+            ]
+        )
+        report.run(args)
+
+    _, kwargs = MockApi.return_value.get_report.call_args
+    assert kwargs.get("extra_vars") == {"currency": "USD"} or (
+        MockApi.return_value.get_report.call_args[0][-1] == {"currency": "USD"}
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -163,6 +163,10 @@ cli = [
     { name = "python-dotenv", version = "1.2.1", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version < '3.10'" },
     { name = "python-dotenv", version = "1.2.2", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version >= '3.10'" },
 ]
+data = [
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version < '3.11'" },
+    { name = "pandas", version = "3.0.1", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version >= '3.11'" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -187,10 +191,11 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "httpx", marker = "extra == 'async'", specifier = ">=0.27" },
+    { name = "pandas", marker = "extra == 'data'", specifier = ">=2.0" },
     { name = "python-dotenv", marker = "extra == 'cli'", specifier = ">=1.2.1" },
     { name = "requests", specifier = ">=2.32.5" },
 ]
-provides-extras = ["cli", "async"]
+provides-extras = ["cli", "async", "data"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Closes #72

## Summary

Adds the `blesta_sdk.cli` package and restructures the CLI into organized subcommand handlers. The `blesta` script entry point is updated to `blesta_sdk.cli.app:main`, which supports both new subcommand syntax and the legacy `--model/--method` flags.

## New CLI structure

```
blesta_sdk.cli.app          ← main() entry point
blesta_sdk.cli.formatters   ← print_json, print_jsonl, print_csv, print_error
blesta_sdk.cli.commands.call
blesta_sdk.cli.commands.extract
blesta_sdk.cli.commands.report
blesta_sdk.cli.commands.discover
```

## New command patterns

```
blesta call clients getList --param status=active
blesta extract clients getList --param status=active --format jsonl|csv
blesta report package_revenue --start 2025-01-01 --end 2025-01-31
blesta discover models
blesta discover methods Clients
blesta discover spec Clients getList
```

## Backward compatibility

- Legacy `blesta --model clients --method getList` still works
- `_cli.py` retains its original `cli()` function (import updated to `core.client`)
- All existing CLI tests pass unchanged

## pyproject.toml changes

- Script updated: `blesta = "blesta_sdk.cli.app:main"`
- Added `data = ["pandas>=2.0"]` optional extra

## Tests

- 34 new tests in `tests/test_cli_commands.py`
- 12 parser-structure tests added to `test_blesta_sdk.py`
- 873 tests pass, 97.63% coverage