### PR TITLE
docs: document SDK, CLI, and MCP namespaces for v0.8.0

### DIFF
--- a/CLI_USAGE.md
+++ b/CLI_USAGE.md
@@ -1,0 +1,204 @@
+# CLI Usage Reference
+
+The `blesta` CLI is a thin wrapper around `blesta_sdk.core` for use from the shell. All
+business logic lives in the Python SDK — the CLI is a dispatch layer only.
+
+## Installation
+
+```bash
+pip install blesta_sdk[cli]   # includes python-dotenv for .env support
+# or
+uv add "blesta_sdk[cli]"
+```
+
+## Credentials
+
+The CLI resolves credentials from environment variables. With the `cli` extra, it also loads
+a `.env` file in the current directory at startup:
+
+```env
+BLESTA_API_URL=https://your-blesta-domain.com/api
+BLESTA_API_USER=your_api_user
+BLESTA_API_KEY=your_api_key
+```
+
+Optional overrides:
+
+```env
+BLESTA_AUTH_METHOD=header    # "basic" (default) or "header"
+```
+
+Generate API credentials in Blesta under **Settings > System > API Access**.
+
+---
+
+## Subcommands
+
+### `blesta call`
+
+Invoke a single API method. Infers the HTTP method from the bundled schema; use `--action`
+to override.
+
+```
+blesta call <model> <method> [--action GET|POST|PUT|DELETE] [--param key=value ...]
+```
+
+**Examples:**
+
+```bash
+# GET — schema-inferred
+blesta call clients getList --param status=active
+
+# GET with nested param
+blesta call clients getList --param status=active --param page=1
+
+# POST — explicit action
+blesta call clients create --action POST --param firstname=John --param lastname=Doe
+
+# Schema-aware (HTTP method inferred automatically)
+blesta call invoices getList
+```
+
+Output is JSON to stdout. On API or HTTP errors, prints a JSON error and exits with code 1.
+
+---
+
+### `blesta extract`
+
+Paginate a list endpoint and collect all records across all pages. Equivalent to
+`BlestaRequest.get_all()`.
+
+```
+blesta extract <model> <method> [--param key=value ...] [--format json|jsonl|csv]
+```
+
+**Formats:**
+
+| Format | Description |
+|--------|-------------|
+| `json` | Pretty-printed JSON array (default) |
+| `jsonl` | One JSON object per line — suitable for streaming / large datasets |
+| `csv` | CSV with header row — only works when all records have the same keys |
+
+**Examples:**
+
+```bash
+# All active clients as JSON
+blesta extract clients getList --param status=active
+
+# Stream all invoices as JSONL
+blesta extract invoices getList --format jsonl
+
+# Export all packages as CSV
+blesta extract packages getAll --format csv
+```
+
+---
+
+### `blesta report`
+
+Fetch a Blesta report for a date range. CSV responses are returned as a JSON array of row
+dicts; JSON responses are returned as-is.
+
+```
+blesta report <type> --start YYYY-MM-DD --end YYYY-MM-DD [--param key=value ...]
+```
+
+**Available report types** (depends on your Blesta installation):
+
+| Type | Description |
+|------|-------------|
+| `package_revenue` | Revenue by package |
+| `tax_liability` | Tax liability by period |
+| `invoice_aging` | Invoice aging summary |
+| `client_data_portability` | GDPR-style data export |
+
+**Examples:**
+
+```bash
+# Q1 2025 revenue report
+blesta report package_revenue --start 2025-01-01 --end 2025-03-31
+
+# Tax liability for January
+blesta report tax_liability --start 2025-01-01 --end 2025-01-31
+```
+
+---
+
+### `blesta discover`
+
+Introspect the bundled API schema without making API calls.
+
+```
+blesta discover models
+blesta discover methods <model>
+blesta discover spec <model> <method>
+```
+
+**Examples:**
+
+```bash
+# List all 71 available models
+blesta discover models
+
+# List all methods for the Clients model
+blesta discover methods clients
+
+# Show full spec for clients.getList
+blesta discover spec clients getList
+```
+
+The `spec` subcommand returns a JSON object with `http_method`, `params`, `return_type`,
+`description`, and `source` fields.
+
+---
+
+## Legacy Mode
+
+The original single-command form is still supported:
+
+```
+blesta --model <model> --method <method> [--action GET|POST|PUT|DELETE] [--params key=value ...] [--last-request]
+```
+
+**Examples:**
+
+```bash
+blesta --model clients --method getList --params status=active
+blesta --model clients --method get --params client_id=1
+blesta --model clients --method create --action POST --params firstname=John lastname=Doe
+blesta --model clients --method getList --last-request
+```
+
+`--last-request` prints the URL and arguments of the most recent request, with sensitive
+fields (API keys, passwords, tokens) automatically redacted as `"***"`.
+
+---
+
+## Output and Errors
+
+All output is JSON to stdout. Errors produce a JSON error object on stdout and exit with
+code 1:
+
+```json
+{"error": "Blesta returned errors: ...", "exit_code": 1}
+```
+
+Pipe to `jq` for filtering:
+
+```bash
+blesta extract clients getList --format jsonl | jq '.id'
+```
+
+---
+
+## Environment Variable Reference
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `BLESTA_API_URL` | Yes | — | API base URL (`https://domain.com/api`) |
+| `BLESTA_API_USER` | Yes | — | API username |
+| `BLESTA_API_KEY` | Yes | — | API key |
+| `BLESTA_AUTH_METHOD` | No | `basic` | `basic` or `header` |
+
+See [`SDK_USAGE.md`](SDK_USAGE.md) for the full programmatic API reference.

--- a/MCP_USAGE.md
+++ b/MCP_USAGE.md
@@ -1,0 +1,397 @@
+# MCP Server Usage Reference
+
+`blesta_sdk.mcp` exposes the full Blesta API surface as an
+[MCP (Model Context Protocol)](https://modelcontextprotocol.io/) server. This lets
+Claude, Cursor, and other MCP-compatible AI tools query, paginate, and introspect a
+Blesta billing instance directly.
+
+## Requirements
+
+- Python 3.10+
+- `pip install blesta_sdk[mcp]`
+
+## Credentials
+
+Set the following environment variables before starting the server:
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `BLESTA_API_URL` | Yes | API base URL (e.g. `https://billing.example.com/api`) |
+| `BLESTA_API_USER` | Yes | API username |
+| `BLESTA_API_KEY` | Yes | API key |
+| `BLESTA_AUTH_METHOD` | No | `basic` (default) or `header` |
+| `BLESTA_ALLOW_HTTP` | No | `true` to permit `http://` URLs (local/dev only) |
+
+Credentials are read **at call time** — you can restart the server with different env vars
+to point at a different Blesta instance.
+
+A `.env` file in the working directory is automatically loaded at startup if `python-dotenv`
+is installed (`pip install blesta_sdk[cli]` or `pip install python-dotenv`).
+
+## Starting the Server
+
+```bash
+blesta-mcp
+```
+
+Or via Python:
+
+```bash
+python -m blesta_sdk.mcp.server
+```
+
+The server runs over stdio (the MCP standard for local tool integrations).
+
+## Client Configuration
+
+### Claude Code
+
+Add to your project's `.claude/settings.json` or user-level MCP config:
+
+```json
+{
+  "mcpServers": {
+    "blesta": {
+      "command": "blesta-mcp",
+      "env": {
+        "BLESTA_API_URL": "https://billing.example.com/api",
+        "BLESTA_API_USER": "api_user",
+        "BLESTA_API_KEY": "api_key"
+      }
+    }
+  }
+}
+```
+
+### Claude Desktop
+
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or
+`%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+
+```json
+{
+  "mcpServers": {
+    "blesta": {
+      "command": "blesta-mcp",
+      "env": {
+        "BLESTA_API_URL": "https://billing.example.com/api",
+        "BLESTA_API_USER": "api_user",
+        "BLESTA_API_KEY": "api_key"
+      }
+    }
+  }
+}
+```
+
+---
+
+## Tools
+
+All tools return JSON strings. Successful calls include `"ok": true`; failures include
+`"ok": false` and an `"errors"` or `"error"` key.
+
+### `blesta_call`
+
+Invoke a single Blesta API method.
+
+**Parameters:**
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `model` | string | required | Model name (e.g. `"Clients"`) |
+| `method` | string | required | Method name (e.g. `"getList"`) |
+| `params` | string | `"{}"` | JSON-encoded parameter dict |
+| `action` | string | `null` | HTTP method override: `GET`, `POST`, `PUT`, or `DELETE` |
+
+**Example:**
+
+```
+blesta_call(model="Clients", method="getList", params='{"status": "active"}')
+```
+
+**Response:**
+
+```json
+{"ok": true, "data": [{"id": 1, "firstname": "Alice", ...}]}
+```
+
+---
+
+### `blesta_get_all`
+
+Paginate a list endpoint and return all records.
+
+**Parameters:**
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `model` | string | required | Model name |
+| `method` | string | required | List method name |
+| `params` | string | `"{}"` | JSON-encoded parameter dict |
+| `max_pages` | int | `null` | Optional page limit |
+
+**Response:**
+
+```json
+{"ok": true, "count": 142, "data": [...]}
+```
+
+---
+
+### `blesta_extract`
+
+Fetch multiple paginated endpoints in a single call.
+
+**Parameters:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `targets` | string | JSON array of `[model, method]` or `[model, method, params]` tuples |
+
+**Example:**
+
+```
+blesta_extract(targets='[["Clients", "getList"], ["Invoices", "getList", {"status": "unpaid"}]]')
+```
+
+**Response:**
+
+```json
+{
+  "ok": true,
+  "data": {
+    "Clients.getList": [...],
+    "Invoices.getList": [...]
+  }
+}
+```
+
+---
+
+### `blesta_count`
+
+Fetch a record count from a Blesta count method.
+
+**Parameters:**
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `model` | string | required | Model name |
+| `method` | string | `"getListCount"` | Count method name |
+| `params` | string | `"{}"` | JSON-encoded parameter dict |
+
+**Response:**
+
+```json
+{"ok": true, "count": 483}
+```
+
+---
+
+### `blesta_get_report`
+
+Fetch a Blesta report for a specific date range.
+
+**Parameters:**
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `report_type` | string | required | Report type (e.g. `"package_revenue"`) |
+| `start_date` | string | required | Start date as `"YYYY-MM-DD"` |
+| `end_date` | string | required | End date as `"YYYY-MM-DD"` |
+| `extra_vars` | string | `"{}"` | Additional `vars[]` parameters as JSON |
+
+**Response (CSV report):**
+
+```json
+{"ok": true, "data": [{"Package": "Basic", "Revenue": "49.99"}, ...]}
+```
+
+---
+
+### `blesta_get_report_series`
+
+Fetch monthly reports across a date range as a flat list of rows.
+
+**Parameters:**
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `report_type` | string | required | Report type |
+| `start_month` | string | required | Start month as `"YYYY-MM"` |
+| `end_month` | string | required | End month as `"YYYY-MM"` |
+| `extra_vars` | string | `"{}"` | Additional `vars[]` parameters as JSON |
+
+Each row includes a `_period` key with the month in `"YYYY-MM"` format.
+
+**Response:**
+
+```json
+{
+  "ok": true,
+  "count": 36,
+  "data": [{"_period": "2024-01", "Package": "Basic", "Revenue": "49.99"}, ...]
+}
+```
+
+---
+
+### `blesta_list_models`
+
+List all available Blesta API models from the bundled schema.
+
+**Parameters:**
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `source` | string | `null` | Filter by `"core"` or `"plugin"`; `null` for all |
+
+**Response:**
+
+```json
+{"ok": true, "models": ["Clients", "Contacts", "Invoices", ...]}
+```
+
+---
+
+### `blesta_list_methods`
+
+List all method names for a specific model.
+
+**Parameters:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `model` | string | Model name (e.g. `"Clients"`) |
+
+**Response:**
+
+```json
+{"ok": true, "model": "Clients", "methods": ["create", "delete", "edit", "get", "getList", ...]}
+```
+
+---
+
+### `blesta_get_method_spec`
+
+Return the full specification for a model/method pair.
+
+**Parameters:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `model` | string | Model name |
+| `method` | string | Method name |
+
+**Response:**
+
+```json
+{
+  "ok": true,
+  "model": "Clients",
+  "method": "getList",
+  "http_method": "GET",
+  "description": "Returns a list of clients",
+  "params": [{"name": "status", "type": "string", "required": false}, ...],
+  "return_type": "array",
+  "source": "core"
+}
+```
+
+---
+
+### `blesta_capabilities_report`
+
+Generate a full capabilities report of the Blesta API surface.
+
+**Parameters:**
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `output_format` | string | `"markdown"` | `"markdown"` or `"json"` |
+
+**Response (markdown):** A Markdown string listing all models and methods.
+
+**Response (json):** A JSON array of model capability objects.
+
+---
+
+## Resources
+
+Resources expose read-only data about the API schema without requiring live API credentials.
+
+| URI | Description |
+|-----|-------------|
+| `blesta://schema/core` | Raw core API schema JSON (63 models) |
+| `blesta://schema/plugin` | Raw plugin schema JSON (8 models) |
+| `blesta://models` | JSON array of all model names |
+| `blesta://models/{model}` | JSON object with model name and method list |
+| `blesta://models/{model}/methods/{method}` | Full method spec JSON |
+| `blesta://capabilities/markdown` | Full API capabilities as Markdown |
+| `blesta://capabilities/json` | Full API capabilities as JSON |
+
+---
+
+## Prompts
+
+Pre-built prompt templates for common Blesta AI workflows:
+
+| Prompt | Description |
+|--------|-------------|
+| `blesta_audit_client` | Audit a client's account status, invoices, and services |
+| `blesta_plan_migration` | Plan a data migration from one Blesta instance to another |
+| `blesta_reconcile_invoices` | Reconcile invoices against payment transaction records |
+| `blesta_extract_customer_snapshot` | Extract a complete customer data snapshot |
+| `blesta_map_to_prime_account` | Map Blesta fields to a target billing system schema |
+
+---
+
+## Important Constraints
+
+### Credentials at call time
+
+Credentials are read from environment variables when each tool is invoked, not at server
+startup. This means:
+
+- The server can be started without credentials configured (tools will fail until env vars are set)
+- Changing env vars between calls takes effect immediately
+- Different MCP client sessions can use the same server process (credentials are per-env, not per-session)
+
+### Transport layer only
+
+The MCP server is a thin adapter over `blesta_sdk.core`. It does not provide:
+
+- **Idempotency** for billing writes — duplicate tool calls can create duplicate records
+- **Transaction semantics** — if a workflow fails mid-way, no rollback occurs
+- **Rate limiting** — the underlying SDK retries 429s, but the MCP layer does not throttle
+
+For billing mutations, always verify the method spec first with `blesta_get_method_spec`,
+confirm the action with the user, and implement a ledger pattern for migrations.
+
+### Read-heavy use case
+
+The MCP server is designed for read-heavy workflows: auditing, reporting, schema
+introspection, data extraction, and migration planning. For bulk creates or updates,
+use the Python SDK directly with a ledger and check-then-create pattern.
+
+---
+
+## Programmatic Usage
+
+To use the MCP package directly in Python (e.g. for testing or embedding):
+
+```python
+from blesta_sdk.mcp.tools import _call_handler, _get_all_handler
+from blesta_sdk.mcp.resources import _models_handler, _model_handler
+
+# All handlers return JSON strings
+import json
+
+result = json.loads(_call_handler("Clients", "getList", '{"status": "active"}'))
+if result["ok"]:
+    clients = result["data"]
+
+models = json.loads(_models_handler())
+```
+
+See the [`blesta_sdk.mcp`](src/blesta_sdk/mcp/) source for all available handlers.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ For async support:
 pip install blesta_sdk[async]
 ```
 
+For the MCP server (Python 3.10+):
+
+```bash
+pip install blesta_sdk[mcp]
+```
+
 ## Quickstart
 
 ### Sync
@@ -631,29 +637,108 @@ BLESTA_API_KEY=your_api_key
 
 Generate API credentials in Blesta under Settings > System > API Access.
 
-### Usage
+### Subcommands
 
 ```
-blesta --model <model> --method <method> [--action GET|POST|PUT|DELETE] [--params key=value ...] [--last-request]
+blesta call   <model> <method> [--action GET|POST|PUT|DELETE] [--param key=value ...]
+blesta extract <model> <method> [--param key=value ...] [--format json|jsonl|csv]
+blesta report  <type> --start YYYY-MM-DD --end YYYY-MM-DD [--param key=value ...]
+blesta discover models|methods <model>|spec <model> <method>
+```
+
+### Legacy mode (still supported)
+
+```
+blesta --model <model> --method <method> [--action GET|POST|PUT|DELETE] [--params key=value ...]
 ```
 
 ### Examples
 
 ```bash
-# List active clients
-blesta --model clients --method getList --params status=active
+# List active clients (subcommand form)
+blesta call clients getList --param status=active
 
-# Get a specific client
-blesta --model clients --method get --params client_id=1
+# Paginate all clients into a JSONL stream
+blesta extract clients getList --format jsonl
 
-# Create a client via POST
-blesta --model clients --method create --action POST --params firstname=John lastname=Doe
+# Fetch a revenue report
+blesta report package_revenue --start 2025-01-01 --end 2025-03-31
 
-# Show the URL and parameters of the request (sensitive values redacted)
-blesta --model clients --method getList --last-request
+# Discover available models
+blesta discover models
+
+# List methods for a model
+blesta discover methods clients
+
+# Show full method spec
+blesta discover spec clients getList
 ```
 
 Output is JSON to stdout. On errors, the error dict is printed as JSON and the process exits with code 1.
+
+See [`CLI_USAGE.md`](CLI_USAGE.md) for the full CLI reference.
+
+## MCP Server
+
+The `blesta-mcp` command exposes the full Blesta API as an [MCP](https://modelcontextprotocol.io/) server for use with Claude, Cursor, and other MCP-compatible AI tools.
+
+Requires Python 3.10+ and the `mcp` extra:
+
+```bash
+pip install blesta_sdk[mcp]
+```
+
+Configure credentials via environment variables (same as the CLI), then run:
+
+```bash
+blesta-mcp
+```
+
+Or register it in your MCP client configuration (e.g. Claude Desktop / Claude Code):
+
+```json
+{
+  "mcpServers": {
+    "blesta": {
+      "command": "blesta-mcp",
+      "env": {
+        "BLESTA_API_URL": "https://billing.example.com/api",
+        "BLESTA_API_USER": "api_user",
+        "BLESTA_API_KEY": "api_key"
+      }
+    }
+  }
+}
+```
+
+### Tools
+
+| Tool | Description |
+|---|---|
+| `blesta_call` | Invoke any single API method |
+| `blesta_get_all` | Paginate a list endpoint and return all records |
+| `blesta_extract` | Fetch multiple paginated endpoints at once |
+| `blesta_count` | Fetch a record count |
+| `blesta_get_report` | Fetch a Blesta report (CSV or JSON) |
+| `blesta_get_report_series` | Fetch monthly reports across a date range |
+| `blesta_list_models` | List all available API models |
+| `blesta_list_methods` | List methods for a model |
+| `blesta_get_method_spec` | Get full spec for a model/method pair |
+| `blesta_capabilities_report` | Generate a full API capabilities report |
+
+### Resources
+
+| Resource URI | Description |
+|---|---|
+| `blesta://schema/core` | Raw core API schema JSON |
+| `blesta://schema/plugin` | Raw plugin schema JSON |
+| `blesta://models` | All available model names |
+| `blesta://models/{model}` | Methods for a specific model |
+| `blesta://models/{model}/methods/{method}` | Full spec for a model/method |
+| `blesta://capabilities/markdown` | API capabilities report (Markdown) |
+| `blesta://capabilities/json` | API capabilities report (JSON) |
+
+See [`MCP_USAGE.md`](MCP_USAGE.md) for the full MCP server reference.
 
 ## API Reference
 

--- a/SDK_USAGE.md
+++ b/SDK_USAGE.md
@@ -2,6 +2,32 @@
 
 Patterns and examples for writing code that uses `blesta_sdk`. This is a companion to `CLAUDE.md` (project conventions).
 
+## Import Paths
+
+The top-level `blesta_sdk` namespace re-exports everything. All public names are importable
+from both the legacy flat path and the new canonical sub-packages:
+
+```python
+# Recommended: top-level imports (always stable)
+from blesta_sdk import BlestaRequest, AsyncBlestaRequest
+from blesta_sdk import BlestaEnvConfig
+from blesta_sdk import BlestaDiscovery, MethodSpec
+from blesta_sdk import BlestaError, BlestaAPIError, BlestaAuthError
+from blesta_sdk import BlestaRateLimitError, BlestaServerError, PaginationError
+from blesta_sdk import BlestaResponse
+
+# Canonical sub-package imports (v0.8+)
+from blesta_sdk.core import BlestaRequest, BlestaEnvConfig
+from blesta_sdk.discovery import BlestaDiscovery, MethodSpec
+```
+
+The `blesta_sdk.mcp` namespace is separate and requires `pip install blesta_sdk[mcp]`:
+
+```python
+from blesta_sdk.mcp.tools import _call_handler   # tool handlers
+from blesta_sdk.mcp.resources import _models_handler  # resource handlers
+```
+
 ## Initialization
 
 All API calls go through `model`/`method` pairs that map to Blesta's REST routes (`/api/model/method.json`). For plugin models, use dot notation: `"plugin.model"`.


### PR DESCRIPTION
Closes #74

## Summary

Adds and updates documentation for the three product surfaces introduced in v0.8.0.

## Changes

### New files

- **`CLI_USAGE.md`** — Full CLI reference: subcommands (`call`, `extract`, `report`, `discover`), legacy `--model/--method` mode, output formats, env var reference
- **`MCP_USAGE.md`** — MCP server reference: installation, client configuration (Claude Code, Claude Desktop), all 10 tools with parameters and example responses, 7 resources, 5 prompts, important constraints

### Updated files

- **`README.md`**
  - Added `pip install blesta_sdk[mcp]` to Installation section
  - Expanded CLI section with subcommand examples and link to `CLI_USAGE.md`
  - Added new MCP Server section with tools table, resources table, and client config example
- **`SDK_USAGE.md`**
  - Added Import Paths section documenting canonical sub-package paths (`blesta_sdk.core`, `blesta_sdk.discovery`) and `blesta_sdk.mcp`