### PR TITLE
Dogfood MCP read-only workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **MCP tool error handling** — API-calling tools (`blesta_call`, `blesta_get_all`,
+  `blesta_extract`, `blesta_count`, `blesta_get_report`, `blesta_get_report_series`) now
+  catch all exceptions (including `RuntimeError` from missing credentials) and return a
+  structured `{"ok": false, "error": "..."}` JSON response instead of raising an unhandled
+  exception that would surface as a raw Python traceback in MCP clients.
+- **`blesta-mcp` startup error** — when the `mcp` package is not installed, `blesta-mcp`
+  now prints a single-line user-friendly error message to stderr and exits with code 1,
+  instead of showing a confusing chained Python traceback.
+
+### Changed
+
+- **`blesta_call` tool description** updated to explicitly note that passing
+  `action="POST"`, `"PUT"`, or `"DELETE"` performs a mutation and that mutations are
+  **not idempotent** — the caller is responsible for deduplication.
+- **MCP prompt templates** — all 5 prompts now include a write-safety ``Note:`` section.
+  Previously only `blesta_reconcile_invoices` had a write-safety note; the other four
+  (`blesta_audit_client`, `blesta_plan_migration`, `blesta_extract_customer_snapshot`,
+  `blesta_map_to_prime_account`) now state they are read-only by default and that the
+  SDK does not provide idempotency for billing writes.
+- `blesta_sdk.mcp.prompts` module docstring updated to document the read-only default
+  and the requirement to confirm mutations with the user.
+
 ## [0.8.0] - 2026-05-27
 
 ### Added

--- a/src/blesta_sdk/mcp/prompts.py
+++ b/src/blesta_sdk/mcp/prompts.py
@@ -3,6 +3,12 @@
 Prompts help AI agents understand how to use the Blesta SDK tools
 for common workflows such as auditing clients, planning migrations,
 or reconciling invoices.
+
+All prompts are read-only by default.  The MCP server is a transport and
+helper layer — it does not provide idempotency for billing writes.  If a
+workflow requires creating or modifying records, confirm the action with
+the user before calling ``blesta_call`` with ``action="POST"`` or
+``action="PUT"``.
 """
 
 from __future__ import annotations
@@ -31,6 +37,9 @@ You are auditing a Blesta client record. Use the following tools in order:
    → Fetch active services.
 
 Summarise the client's account status, outstanding balance, and service list.
+
+Note: This workflow is read-only. Do not modify records unless the user
+explicitly requests it and you have confirmed the intended change.
 """
 
 PLAN_MIGRATION_PROMPT = """\
@@ -45,6 +54,11 @@ For each model:
 - Estimate record counts with blesta_count().
 
 Produce a migration plan that lists models in dependency order.
+
+Note: This is a planning workflow only. The SDK does not provide idempotency
+for billing writes. Any migration that creates records must use a ledger
+(source_id → target_id mapping) and a check-before-create pattern to avoid
+duplicates. Do not execute writes without a confirmed deduplication strategy.
 """
 
 RECONCILE_INVOICES_PROMPT = """\
@@ -58,12 +72,12 @@ You are reconciling Blesta invoices against payment records.
 
 Report any invoices that lack matching transactions.
 
-Note: This SDK is read-only in this context. Do not attempt to create or
-modify records unless explicitly authorised.
+Note: This workflow is read-only. Do not attempt to create or modify records
+unless explicitly authorised by the user.
 """
 
 EXTRACT_CUSTOMER_SNAPSHOT_PROMPT = """\
-Extract a complete snapshot of a Blesta customer for export.
+Extract a complete snapshot of a Blesta customer for export or analysis.
 
 Use blesta_extract with these targets:
 - ["Clients", "getList"]
@@ -73,6 +87,10 @@ Use blesta_extract with these targets:
 
 Then use blesta_capabilities_report() to understand what other models
 might contain relevant customer data.
+
+Note: This workflow is read-only. The extracted data is for analysis or
+export only. Do not write back to Blesta without explicit user confirmation
+and a deduplication strategy.
 """
 
 MAP_TO_PRIME_ACCOUNT_PROMPT = """\
@@ -86,6 +104,10 @@ You are mapping Blesta client records to a target billing system.
 
 Note: Field names visible in API responses may differ from schema param names.
 Always verify with a live sample.
+
+This is a mapping and planning workflow only. The SDK does not provide
+idempotency for billing writes. Any import into the target system must use
+a ledger and check-before-create pattern to prevent duplicate records.
 """
 
 # ---------------------------------------------------------------------------

--- a/src/blesta_sdk/mcp/server.py
+++ b/src/blesta_sdk/mcp/server.py
@@ -78,10 +78,9 @@ def main() -> None:
 
     Starts the MCP server over stdio transport (the default for local
     AI-agent integrations).
-
-    :raises ImportError: If ``mcp`` is not installed.
-    :raises RuntimeError: If Blesta credentials are not configured.
     """
+    import sys
+
     try:
         from dotenv import load_dotenv
 
@@ -89,7 +88,12 @@ def main() -> None:
     except ImportError:
         pass
 
-    mcp_server = _build_server()
+    try:
+        mcp_server = _build_server()
+    except ImportError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
     logger.info("Starting %s MCP server v%s", _SERVER_NAME, _SERVER_VERSION)
     mcp_server.run()
 

--- a/src/blesta_sdk/mcp/tools.py
+++ b/src/blesta_sdk/mcp/tools.py
@@ -31,21 +31,30 @@ def _call_handler(
 ) -> str:
     """Invoke a single Blesta API method.
 
+    HTTP method is inferred from the bundled schema when *action* is omitted.
+    Pass ``action="POST"``, ``"PUT"``, or ``"DELETE"`` explicitly for mutating
+    operations.  Mutations are **not idempotent** — the caller is responsible
+    for deduplication and ledger tracking.
+
     :param model: API model name (e.g. ``"Clients"``).
     :param method: API method name (e.g. ``"getList"``).
     :param params: JSON string of request parameters.
     :param action: HTTP method override (GET/POST/PUT/DELETE).
     :return: JSON-serialised response data.
     """
-    args: dict[str, Any] = json.loads(params) if params else {}
-    client = _build_client()
-    if action:
-        response = client.submit(model, method, args, action.upper())
-    else:
-        response = client.call(model, method, args)
-    if response.status_code == 200:
-        return json.dumps({"ok": True, "data": response.data})
-    return json.dumps({"ok": False, "errors": response.errors()})
+    try:
+        args: dict[str, Any] = json.loads(params) if params else {}
+        client = _build_client()
+        if action:
+            response = client.submit(model, method, args, action.upper())
+        else:
+            response = client.call(model, method, args)
+        if response.status_code == 200:
+            return json.dumps({"ok": True, "data": response.data})
+        return json.dumps({"ok": False, "errors": response.errors()})
+    except Exception as exc:
+        logger.debug("_call_handler error: %s", exc)
+        return json.dumps({"ok": False, "error": str(exc)})
 
 
 def _get_all_handler(
@@ -62,10 +71,14 @@ def _get_all_handler(
     :param max_pages: Optional page limit.
     :return: JSON-serialised list of all records.
     """
-    args: dict[str, Any] = json.loads(params) if params else {}
-    client = _build_client()
-    rows = client.get_all(model, method, args or None, max_pages=max_pages)
-    return json.dumps({"ok": True, "count": len(rows), "data": rows})
+    try:
+        args: dict[str, Any] = json.loads(params) if params else {}
+        client = _build_client()
+        rows = client.get_all(model, method, args or None, max_pages=max_pages)
+        return json.dumps({"ok": True, "count": len(rows), "data": rows})
+    except Exception as exc:
+        logger.debug("_get_all_handler error: %s", exc)
+        return json.dumps({"ok": False, "error": str(exc)})
 
 
 def _extract_handler(
@@ -77,10 +90,14 @@ def _extract_handler(
         tuples.
     :return: JSON-serialised dict mapping ``model.method`` to record lists.
     """
-    target_list = json.loads(targets)
-    client = _build_client()
-    results = client.extract([tuple(t) for t in target_list])  # type: ignore[arg-type]
-    return json.dumps({"ok": True, "data": results})
+    try:
+        target_list = json.loads(targets)
+        client = _build_client()
+        results = client.extract([tuple(t) for t in target_list])  # type: ignore[arg-type]
+        return json.dumps({"ok": True, "data": results})
+    except Exception as exc:
+        logger.debug("_extract_handler error: %s", exc)
+        return json.dumps({"ok": False, "error": str(exc)})
 
 
 def _count_handler(
@@ -95,10 +112,14 @@ def _count_handler(
     :param params: JSON string of request parameters.
     :return: JSON-serialised count.
     """
-    args: dict[str, Any] = json.loads(params) if params else {}
-    client = _build_client()
-    count = client.count(model, method, args or None)
-    return json.dumps({"ok": True, "count": count})
+    try:
+        args: dict[str, Any] = json.loads(params) if params else {}
+        client = _build_client()
+        count = client.count(model, method, args or None)
+        return json.dumps({"ok": True, "count": count})
+    except Exception as exc:
+        logger.debug("_count_handler error: %s", exc)
+        return json.dumps({"ok": False, "error": str(exc)})
 
 
 def _get_report_handler(
@@ -115,14 +136,18 @@ def _get_report_handler(
     :param extra_vars: JSON string of additional vars[] parameters.
     :return: JSON-serialised report rows (CSV parsed) or raw data.
     """
-    extra: dict[str, str] = json.loads(extra_vars) if extra_vars else {}
-    client = _build_client()
-    response = client.get_report(report_type, start_date, end_date, extra or None)
-    if response.status_code != 200:
-        return json.dumps({"ok": False, "error": f"HTTP {response.status_code}"})
-    if response.is_csv:
-        return json.dumps({"ok": True, "data": response.csv_data or []})
-    return json.dumps({"ok": True, "data": response.data})
+    try:
+        extra: dict[str, str] = json.loads(extra_vars) if extra_vars else {}
+        client = _build_client()
+        response = client.get_report(report_type, start_date, end_date, extra or None)
+        if response.status_code != 200:
+            return json.dumps({"ok": False, "error": f"HTTP {response.status_code}"})
+        if response.is_csv:
+            return json.dumps({"ok": True, "data": response.csv_data or []})
+        return json.dumps({"ok": True, "data": response.data})
+    except Exception as exc:
+        logger.debug("_get_report_handler error: %s", exc)
+        return json.dumps({"ok": False, "error": str(exc)})
 
 
 def _get_report_series_handler(
@@ -139,10 +164,16 @@ def _get_report_series_handler(
     :param extra_vars: JSON string of additional vars[] parameters.
     :return: JSON-serialised list of row dicts with ``_period`` key.
     """
-    extra: dict[str, str] = json.loads(extra_vars) if extra_vars else {}
-    client = _build_client()
-    rows = client.get_report_series(report_type, start_month, end_month, extra or None)
-    return json.dumps({"ok": True, "count": len(rows), "data": rows})
+    try:
+        extra: dict[str, str] = json.loads(extra_vars) if extra_vars else {}
+        client = _build_client()
+        rows = client.get_report_series(
+            report_type, start_month, end_month, extra or None
+        )
+        return json.dumps({"ok": True, "count": len(rows), "data": rows})
+    except Exception as exc:
+        logger.debug("_get_report_series_handler error: %s", exc)
+        return json.dumps({"ok": False, "error": str(exc)})
 
 
 def _list_models_handler(source: str | None = None) -> str:
@@ -227,7 +258,12 @@ TOOL_REGISTRY: list[tuple[str, Any, str]] = [
     (
         "blesta_call",
         _call_handler,
-        "Invoke a single Blesta API method. Returns JSON response data.",
+        (
+            "Invoke a single Blesta API method. HTTP method is inferred from the "
+            "schema when action is omitted. For mutations (POST/PUT/DELETE), pass "
+            "action explicitly. Mutations are not idempotent — the caller is "
+            "responsible for deduplication."
+        ),
     ),
     (
         "blesta_get_all",

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -631,3 +631,145 @@ def test_get_report_handler_json_data():
     data = json.loads(result)
     assert data["ok"] is True
     assert data["data"] == {"rows": [1, 2, 3]}
+
+
+# ---------------------------------------------------------------------------
+# Tool error handling: missing credentials → structured JSON error
+# ---------------------------------------------------------------------------
+
+
+def test_call_handler_missing_creds_returns_json_error():
+    """_call_handler returns ok=False JSON when credentials are missing."""
+    from blesta_sdk.mcp.tools import _call_handler
+
+    with patch.dict(os.environ, {}, clear=True):
+        result = _call_handler("Clients", "getList")
+
+    data = json.loads(result)
+    assert data["ok"] is False
+    assert "error" in data
+    assert "BLESTA_API" in data["error"]
+
+
+def test_get_all_handler_missing_creds_returns_json_error():
+    """_get_all_handler returns ok=False JSON when credentials are missing."""
+    from blesta_sdk.mcp.tools import _get_all_handler
+
+    with patch.dict(os.environ, {}, clear=True):
+        result = _get_all_handler("Clients", "getList")
+
+    data = json.loads(result)
+    assert data["ok"] is False
+    assert "error" in data
+
+
+def test_extract_handler_missing_creds_returns_json_error():
+    """_extract_handler returns ok=False JSON when credentials are missing."""
+    from blesta_sdk.mcp.tools import _extract_handler
+
+    with patch.dict(os.environ, {}, clear=True):
+        result = _extract_handler('[["Clients", "getList"]]')
+
+    data = json.loads(result)
+    assert data["ok"] is False
+    assert "error" in data
+
+
+def test_count_handler_missing_creds_returns_json_error():
+    """_count_handler returns ok=False JSON when credentials are missing."""
+    from blesta_sdk.mcp.tools import _count_handler
+
+    with patch.dict(os.environ, {}, clear=True):
+        result = _count_handler("Clients")
+
+    data = json.loads(result)
+    assert data["ok"] is False
+    assert "error" in data
+
+
+def test_get_report_handler_missing_creds_returns_json_error():
+    """_get_report_handler returns ok=False JSON when credentials are missing."""
+    from blesta_sdk.mcp.tools import _get_report_handler
+
+    with patch.dict(os.environ, {}, clear=True):
+        result = _get_report_handler("package_revenue", "2025-01-01", "2025-01-31")
+
+    data = json.loads(result)
+    assert data["ok"] is False
+    assert "error" in data
+
+
+def test_get_report_series_handler_missing_creds_returns_json_error():
+    """_get_report_series_handler returns ok=False JSON when credentials are missing."""
+    from blesta_sdk.mcp.tools import _get_report_series_handler
+
+    with patch.dict(os.environ, {}, clear=True):
+        result = _get_report_series_handler("package_revenue", "2025-01", "2025-03")
+
+    data = json.loads(result)
+    assert data["ok"] is False
+    assert "error" in data
+
+
+# ---------------------------------------------------------------------------
+# server.main() ImportError → clean stderr exit
+# ---------------------------------------------------------------------------
+
+
+def test_main_import_error_exits_cleanly(capsys):
+    """main() exits with code 1 and prints clean error when mcp not installed."""
+    from blesta_sdk.mcp.server import main
+
+    with (
+        patch(
+            "blesta_sdk.mcp.server._build_server",
+            side_effect=ImportError("blesta-mcp requires the mcp package."),
+        ),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        main()
+
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert "blesta-mcp requires the mcp package" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# Prompt write-safety: all prompts must include a safety note
+# ---------------------------------------------------------------------------
+
+
+def test_all_prompts_have_write_safety_note():
+    """Every prompt template must contain a read-only or write-safety note."""
+    from blesta_sdk.mcp.prompts import PROMPT_REGISTRY
+
+    safety_terms = [
+        "read-only",
+        "do not",
+        "not provide idempotency",
+        "deduplication",
+        "ledger",
+        "not attempt",
+        "confirm",
+    ]
+    for name, template, _desc in PROMPT_REGISTRY:
+        lower = template.lower()
+        has_note = any(term in lower for term in safety_terms)
+        assert has_note, (
+            f"Prompt {name!r} is missing a write-safety note. "
+            f"Add a 'Note:' section with safety guidance."
+        )
+
+
+# ---------------------------------------------------------------------------
+# blesta_call description includes mutation warning
+# ---------------------------------------------------------------------------
+
+
+def test_blesta_call_description_mentions_mutation():
+    """blesta_call tool description must mention mutation idempotency risk."""
+    from blesta_sdk.mcp.tools import TOOL_REGISTRY
+
+    call_entry = next(e for e in TOOL_REGISTRY if e[0] == "blesta_call")
+    desc = call_entry[2].lower()
+    assert "idempotent" in desc or "mutation" in desc or "deduplication" in desc


### PR DESCRIPTION
Closes #81

## Summary

Dogfooding pass on the v0.8.0 MCP server against practical read-only Blesta workflows. Found and fixed several usability gaps.

## What was validated

**Workflow 1: API discovery (no credentials needed)**
- `blesta_list_models` — 71 models ✓
- `blesta_list_methods` — 67 methods for Clients ✓
- `blesta_get_method_spec` — full spec for Clients.getList ✓
- `blesta_capabilities_report` — markdown (17,757 chars) and JSON (71 models) ✓
- All 7 resources readable ✓ (5 static + 2 template)

**Package/install**
- `blesta_sdk` importable ✓
- `blesta_sdk.mcp` importable without mcp extra ✓
- `blesta-mcp` entry point present ✓
- `blesta` entry point present ✓

**Tool/resource/prompt registries**
- All 10 tools present ✓
- All 7 resources present ✓
- All 5 prompts present ✓

## Gaps found and fixed

### 1. Unhandled  in API-calling tools
When `BLESTA_API_URL/USER/KEY` are missing, the 6 API-calling tools raised `RuntimeError` unhandled — agents received a raw Python traceback. Fixed by wrapping each handler in `try/except Exception` and returning `{ok: false, error: ...}`.

### 2.  confusing startup traceback
Running `blesta-mcp` without `mcp` installed showed a multi-frame chained Python traceback. The friendly error message was there but buried. Fixed: `main()` now catches `ImportError` and prints a single clean line to stderr, then exits 1.

**Before:**
```
Traceback (most recent call last):
  File .../server.py, line 52, in _build_server
    from mcp.server.fastmcp import FastMCP
ModuleNotFoundError: No module named 'mcp'
The above exception was the direct cause of the following exception:
...
ImportError: blesta-mcp requires the mcp package. Install it with: pip install blesta_sdk[mcp]
```

**After:**
```
Error: blesta-mcp requires the mcp package. Install it with: pip install blesta_sdk[mcp]
```

### 3. Write-safety notes missing from 4 of 5 prompts
Only `blesta_reconcile_invoices` had a write-safety note. The other 4 (`blesta_audit_client`, `blesta_plan_migration`, `blesta_extract_customer_snapshot`, `blesta_map_to_prime_account`) now include a `Note:` section stating they are read-only and that the SDK does not provide idempotency for billing writes.

### 4. `blesta_call` description silent on mutation risk
Updated description to explicitly state that passing `action="POST"`, `"PUT"`, or `"DELETE"` performs a mutation and mutations are not idempotent.

## Tests added (9 new)

- 6 × missing-credentials tests: each API-calling tool returns `{"ok": false, "error": ...}` instead of raising
- `test_main_import_error_exits_cleanly`: verifies exit(1) + clean stderr message
- `test_all_prompts_have_write_safety_note`: asserts every prompt includes safety language
- `test_blesta_call_description_mentions_mutation`: asserts description includes idempotency/mutation/deduplication

## Test results

| Check | Result |
|-------|--------|
| `pytest -m "not integration"` | 929 passed, 1 deselected |
| Coverage | 97.88% |
| `ruff check` | All checks passed |
| `black --check` | 58 files unchanged |
| `uv build` | Built 0.8.0 artifacts |
| `twine check` | PASSED |

## Safety notes

- All changes are backward-compatible
- No mutation-first examples added
- No retry or HTTP safety behavior changed
- Credential redaction behavior unchanged
- No architecture changes

## Follow-up issues (potential v0.8.2+)

- Add CI job for `blesta_sdk[mcp]` install validation on Python 3.10+
- Add typed schemas for MCP tool inputs using pydantic models (optional)
- Add read-only extraction cookbook in `docs/`