### PR TITLE
release 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-05-27
+
 ### Fixed
 
 - **MCP tool error handling** — API-calling tools (`blesta_call`, `blesta_get_all`,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blesta_sdk"
-version = "0.8.0"
+version = "0.8.1"
 description = "Python SDK and CLI for the Blesta billing platform REST API"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -169,7 +169,7 @@ wheels = [
 
 [[package]]
 name = "blesta-sdk"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "requests" },


### PR DESCRIPTION
Version bump and CHANGELOG freeze for v0.8.1.

Closes the [Unreleased] section from the dogfooding pass (#81 / #82):
- MCP tool error handling (missing credentials → structured JSON error)
- `blesta-mcp` clean startup error message
- Prompt write-safety notes
- `blesta_call` mutation description