### PR TITLE
Consolidate CLI credential resolution into _build_cli_client()

### DIFF
--- a/src/blesta_sdk/cli/app.py
+++ b/src/blesta_sdk/cli/app.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import argparse
 import sys
 
-from blesta_sdk.core.client import BlestaRequest
+from blesta_sdk.cli.formatters import _build_cli_client
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -115,47 +115,19 @@ def main() -> None:
 def _run_legacy(args: argparse.Namespace) -> None:
     """Handle the legacy ``--model/--method`` syntax.
 
-    Delegates to the original :func:`~blesta_sdk._cli.cli` implementation
-    so existing callers and test patches continue to work unchanged.
+    Uses :func:`~blesta_sdk.cli.formatters._build_cli_client` to resolve
+    credentials from environment variables and construct the API client.
 
     :param args: Parsed arguments from the top-level parser.
     """
-    # Reconstruct sys.argv as if the legacy CLI was called directly.
-    # This is the simplest way to reuse the original argument parsing
-    # without duplicating credential / validation logic.
-    import os
+    import logging
 
     from blesta_sdk.cli.formatters import print_error, print_json
-
-    url = os.getenv("BLESTA_API_URL")
-    user = os.getenv("BLESTA_API_USER")
-    key = os.getenv("BLESTA_API_KEY")
-
-    if not all([url, user, key]):
-        print_error(
-            "Missing API credentials."
-            " Set BLESTA_API_URL, BLESTA_API_USER, and BLESTA_API_KEY."
-        )
 
     if not args.model:
         print_error("--model is required in legacy mode")
     if not args.method:
         print_error("--method is required in legacy mode")
-
-    auth_method = os.getenv("BLESTA_AUTH_METHOD", "basic").strip().lower()
-    if auth_method not in ("basic", "header"):
-        print_error(
-            f"Invalid BLESTA_AUTH_METHOD {auth_method!r}:"
-            " must be 'basic' or 'header'."
-        )
-    allow_http = os.getenv("BLESTA_ALLOW_HTTP", "").strip().lower() in {
-        "1",
-        "true",
-        "yes",
-        "on",
-    }
-
-    import logging
 
     log = logging.getLogger(__name__)
     params: dict[str, str] = {}
@@ -169,13 +141,7 @@ def _run_legacy(args: argparse.Namespace) -> None:
             log.warning("Duplicate CLI param '%s' — last value wins", k)
         params[k] = v
 
-    api = BlestaRequest(
-        url,
-        user,
-        key,
-        auth_method=auth_method,
-        allow_http=allow_http,
-    )
+    api = _build_cli_client()
     response = api.submit(args.model, args.method, params, args.action)
 
     if response.status_code == 200:

--- a/src/blesta_sdk/cli/commands/call.py
+++ b/src/blesta_sdk/cli/commands/call.py
@@ -3,10 +3,9 @@
 from __future__ import annotations
 
 import logging
-import os
 from typing import TYPE_CHECKING
 
-from blesta_sdk.core.client import BlestaRequest
+from blesta_sdk.cli.formatters import _build_cli_client
 
 if TYPE_CHECKING:
     import argparse
@@ -50,24 +49,6 @@ def run(args: argparse.Namespace) -> None:
     """
     from blesta_sdk.cli.formatters import print_error, print_json
 
-    url = os.getenv("BLESTA_API_URL")
-    user = os.getenv("BLESTA_API_USER")
-    key = os.getenv("BLESTA_API_KEY")
-
-    if not all([url, user, key]):
-        print_error(
-            "Missing API credentials."
-            " Set BLESTA_API_URL, BLESTA_API_USER, and BLESTA_API_KEY."
-        )
-
-    auth_method = os.getenv("BLESTA_AUTH_METHOD", "basic").strip().lower()
-    allow_http = os.getenv("BLESTA_ALLOW_HTTP", "").strip().lower() in {
-        "1",
-        "true",
-        "yes",
-        "on",
-    }
-
     params: dict[str, str] = {}
     for raw in args.params or []:
         if not raw or "=" not in raw:
@@ -79,13 +60,7 @@ def run(args: argparse.Namespace) -> None:
             logger.warning("Duplicate CLI param '%s' — last value wins", k)
         params[k] = v
 
-    api = BlestaRequest(
-        url,
-        user,
-        key,
-        auth_method=auth_method,
-        allow_http=allow_http,
-    )
+    api = _build_cli_client()
 
     if args.action is not None:
         response = api.submit(args.model, args.method, params, args.action)

--- a/src/blesta_sdk/cli/commands/extract.py
+++ b/src/blesta_sdk/cli/commands/extract.py
@@ -3,10 +3,9 @@
 from __future__ import annotations
 
 import logging
-import os
 from typing import TYPE_CHECKING
 
-from blesta_sdk.core.client import BlestaRequest
+from blesta_sdk.cli.formatters import _build_cli_client
 
 if TYPE_CHECKING:
     import argparse
@@ -60,24 +59,6 @@ def run(args: argparse.Namespace) -> None:
         print_jsonl,
     )
 
-    url = os.getenv("BLESTA_API_URL")
-    user = os.getenv("BLESTA_API_USER")
-    key = os.getenv("BLESTA_API_KEY")
-
-    if not all([url, user, key]):
-        print_error(
-            "Missing API credentials."
-            " Set BLESTA_API_URL, BLESTA_API_USER, and BLESTA_API_KEY."
-        )
-
-    auth_method = os.getenv("BLESTA_AUTH_METHOD", "basic").strip().lower()
-    allow_http = os.getenv("BLESTA_ALLOW_HTTP", "").strip().lower() in {
-        "1",
-        "true",
-        "yes",
-        "on",
-    }
-
     params: dict[str, str] = {}
     for raw in args.params or []:
         if not raw or "=" not in raw:
@@ -89,13 +70,7 @@ def run(args: argparse.Namespace) -> None:
             logger.warning("Duplicate CLI param '%s' — last value wins", k)
         params[k] = v
 
-    api = BlestaRequest(
-        url,
-        user,
-        key,
-        auth_method=auth_method,
-        allow_http=allow_http,
-    )
+    api = _build_cli_client()
 
     rows = api.get_all(args.model, args.method, params or None)
 

--- a/src/blesta_sdk/cli/commands/report.py
+++ b/src/blesta_sdk/cli/commands/report.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-import os
 from typing import TYPE_CHECKING
 
-from blesta_sdk.core.client import BlestaRequest
+from blesta_sdk.cli.formatters import _build_cli_client
 
 if TYPE_CHECKING:
     import argparse
@@ -54,24 +53,6 @@ def run(args: argparse.Namespace) -> None:
     """
     from blesta_sdk.cli.formatters import print_error, print_json
 
-    url = os.getenv("BLESTA_API_URL")
-    user = os.getenv("BLESTA_API_USER")
-    key = os.getenv("BLESTA_API_KEY")
-
-    if not all([url, user, key]):
-        print_error(
-            "Missing API credentials."
-            " Set BLESTA_API_URL, BLESTA_API_USER, and BLESTA_API_KEY."
-        )
-
-    auth_method = os.getenv("BLESTA_AUTH_METHOD", "basic").strip().lower()
-    allow_http = os.getenv("BLESTA_ALLOW_HTTP", "").strip().lower() in {
-        "1",
-        "true",
-        "yes",
-        "on",
-    }
-
     extra_vars: dict[str, str] = {}
     for raw in args.params or []:
         if not raw or "=" not in raw:
@@ -79,13 +60,7 @@ def run(args: argparse.Namespace) -> None:
         k, v = raw.split("=", 1)
         extra_vars[k] = v
 
-    api = BlestaRequest(
-        url,
-        user,
-        key,
-        auth_method=auth_method,
-        allow_http=allow_http,
-    )
+    api = _build_cli_client()
 
     response = api.get_report(
         args.report_type,

--- a/src/blesta_sdk/cli/formatters.py
+++ b/src/blesta_sdk/cli/formatters.py
@@ -1,10 +1,54 @@
-"""Output formatters for the Blesta CLI."""
+"""Output formatters and CLI client helper for the Blesta CLI."""
 
 from __future__ import annotations
 
 import json
+import os
 import sys
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from blesta_sdk.core.client import BlestaRequest
+
+_TRUTHY_ENV = {"1", "true", "yes", "on"}
+
+
+def _build_cli_client() -> BlestaRequest:
+    """Create a :class:`~blesta_sdk.core.client.BlestaRequest` from CLI env vars.
+
+    Reads ``BLESTA_API_URL``, ``BLESTA_API_USER``, ``BLESTA_API_KEY``,
+    ``BLESTA_AUTH_METHOD`` (default ``"basic"``), and ``BLESTA_ALLOW_HTTP``
+    from the environment and returns a configured client.
+
+    Calls :func:`print_error` (which exits) if any required credential is
+    missing or if ``BLESTA_AUTH_METHOD`` is not ``"basic"`` or ``"header"``.
+
+    :return: Configured :class:`~blesta_sdk.core.client.BlestaRequest`.
+    """
+    from blesta_sdk.core.client import BlestaRequest
+
+    url = os.getenv("BLESTA_API_URL")
+    user = os.getenv("BLESTA_API_USER")
+    key = os.getenv("BLESTA_API_KEY")
+    if not all([url, user, key]):
+        print_error(
+            "Missing API credentials."
+            " Set BLESTA_API_URL, BLESTA_API_USER, and BLESTA_API_KEY."
+        )
+    auth_method = os.getenv("BLESTA_AUTH_METHOD", "basic").strip().lower()
+    if auth_method not in ("basic", "header"):
+        print_error(
+            f"Invalid BLESTA_AUTH_METHOD {auth_method!r}:"
+            " must be 'basic' or 'header'."
+        )
+    allow_http = os.getenv("BLESTA_ALLOW_HTTP", "").strip().lower() in _TRUTHY_ENV
+    return BlestaRequest(  # type: ignore[arg-type]
+        url,
+        user,
+        key,
+        auth_method=auth_method,  # type: ignore[arg-type]
+        allow_http=allow_http,
+    )
 
 
 def print_json(data: Any, *, indent: int = 4) -> None:

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -59,15 +59,74 @@ def test_print_error_exits(capsys):
 
 
 # ---------------------------------------------------------------------------
-# blesta call
+# _build_cli_client helper
 # ---------------------------------------------------------------------------
-
 
 _CREDS = {
     "BLESTA_API_URL": "https://example.com/api",
     "BLESTA_API_USER": "user",
     "BLESTA_API_KEY": "key",
 }
+
+
+def test_build_cli_client_returns_blesta_request():
+    from blesta_sdk.cli.formatters import _build_cli_client
+    from blesta_sdk.core.client import BlestaRequest
+
+    with patch.dict(os.environ, _CREDS):
+        client = _build_cli_client()
+    assert isinstance(client, BlestaRequest)
+
+
+def test_build_cli_client_missing_creds(capsys):
+    from blesta_sdk.cli.formatters import _build_cli_client
+
+    with (
+        patch.dict(os.environ, {}, clear=True),
+        pytest.raises(SystemExit),
+    ):
+        _build_cli_client()
+    out = capsys.readouterr().out
+    assert "BLESTA_API_URL" in out
+
+
+def test_build_cli_client_invalid_auth_method(capsys):
+    from blesta_sdk.cli.formatters import _build_cli_client
+
+    creds = {**_CREDS, "BLESTA_AUTH_METHOD": "digest"}
+    with (
+        patch.dict(os.environ, creds),
+        pytest.raises(SystemExit),
+    ):
+        _build_cli_client()
+    out = capsys.readouterr().out
+    assert "BLESTA_AUTH_METHOD" in out
+
+
+def test_build_cli_client_allow_http():
+    from blesta_sdk.cli.formatters import _build_cli_client
+    from blesta_sdk.core.client import BlestaRequest
+
+    creds = {**_CREDS, "BLESTA_ALLOW_HTTP": "true"}
+    with patch.dict(os.environ, creds):
+        client = _build_cli_client()
+    assert isinstance(client, BlestaRequest)
+
+
+def test_build_cli_client_header_auth():
+    from blesta_sdk.cli.formatters import _build_cli_client
+    from blesta_sdk.core.client import BlestaRequest
+
+    creds = {**_CREDS, "BLESTA_AUTH_METHOD": "header"}
+    with patch.dict(os.environ, creds):
+        client = _build_cli_client()
+    assert isinstance(client, BlestaRequest)
+    assert client.auth_method == "header"
+
+
+# ---------------------------------------------------------------------------
+# blesta call
+# ---------------------------------------------------------------------------
 
 
 def _mock_response(data=None, status_code=200):
@@ -85,9 +144,9 @@ def test_call_run_get(capsys):
     mock_resp = _mock_response(data=[{"id": 1}])
     with (
         patch.dict(os.environ, _CREDS),
-        patch("blesta_sdk.cli.commands.call.BlestaRequest") as MockApi,
+        patch("blesta_sdk.cli.commands.call._build_cli_client") as MockBuild,
     ):
-        MockApi.return_value.submit.return_value = mock_resp
+        MockBuild.return_value.submit.return_value = mock_resp
         args = _build_parser().parse_args(
             [
                 "call",
@@ -112,9 +171,9 @@ def test_call_run_inferred_method(capsys):
     mock_resp = _mock_response(data={"id": 5})
     with (
         patch.dict(os.environ, _CREDS),
-        patch("blesta_sdk.cli.commands.call.BlestaRequest") as MockApi,
+        patch("blesta_sdk.cli.commands.call._build_cli_client") as MockBuild,
     ):
-        MockApi.return_value.call.return_value = mock_resp
+        MockBuild.return_value.call.return_value = mock_resp
         args = _build_parser().parse_args(["call", "clients", "getList"])
         call.run(args)
 
@@ -141,9 +200,9 @@ def test_call_run_non200(capsys):
     mock_resp = _mock_response(status_code=403)
     with (
         patch.dict(os.environ, _CREDS),
-        patch("blesta_sdk.cli.commands.call.BlestaRequest") as MockApi,
+        patch("blesta_sdk.cli.commands.call._build_cli_client") as MockBuild,
     ):
-        MockApi.return_value.submit.return_value = mock_resp
+        MockBuild.return_value.submit.return_value = mock_resp
         args = _build_parser().parse_args(
             ["call", "clients", "getList", "--action", "GET"]
         )
@@ -180,9 +239,9 @@ def test_extract_run_json(capsys):
     rows = [{"id": 1}, {"id": 2}]
     with (
         patch.dict(os.environ, _CREDS),
-        patch("blesta_sdk.cli.commands.extract.BlestaRequest") as MockApi,
+        patch("blesta_sdk.cli.commands.extract._build_cli_client") as MockBuild,
     ):
-        MockApi.return_value.get_all.return_value = rows
+        MockBuild.return_value.get_all.return_value = rows
         args = _build_parser().parse_args(["extract", "clients", "getList"])
         extract.run(args)
 
@@ -198,9 +257,9 @@ def test_extract_run_jsonl(capsys):
     rows = [{"id": 1}, {"id": 2}]
     with (
         patch.dict(os.environ, _CREDS),
-        patch("blesta_sdk.cli.commands.extract.BlestaRequest") as MockApi,
+        patch("blesta_sdk.cli.commands.extract._build_cli_client") as MockBuild,
     ):
-        MockApi.return_value.get_all.return_value = rows
+        MockBuild.return_value.get_all.return_value = rows
         args = _build_parser().parse_args(
             ["extract", "clients", "getList", "--format", "jsonl"]
         )
@@ -217,9 +276,9 @@ def test_extract_run_csv(capsys):
     rows = [{"name": "Alice"}, {"name": "Bob"}]
     with (
         patch.dict(os.environ, _CREDS),
-        patch("blesta_sdk.cli.commands.extract.BlestaRequest") as MockApi,
+        patch("blesta_sdk.cli.commands.extract._build_cli_client") as MockBuild,
     ):
-        MockApi.return_value.get_all.return_value = rows
+        MockBuild.return_value.get_all.return_value = rows
         args = _build_parser().parse_args(
             ["extract", "clients", "getList", "--format", "csv"]
         )
@@ -258,9 +317,9 @@ def test_report_run_csv_response(capsys):
 
     with (
         patch.dict(os.environ, _CREDS),
-        patch("blesta_sdk.cli.commands.report.BlestaRequest") as MockApi,
+        patch("blesta_sdk.cli.commands.report._build_cli_client") as MockBuild,
     ):
-        MockApi.return_value.get_report.return_value = mock_resp
+        MockBuild.return_value.get_report.return_value = mock_resp
         args = _build_parser().parse_args(
             [
                 "report",
@@ -289,9 +348,9 @@ def test_report_run_json_response(capsys):
 
     with (
         patch.dict(os.environ, _CREDS),
-        patch("blesta_sdk.cli.commands.report.BlestaRequest") as MockApi,
+        patch("blesta_sdk.cli.commands.report._build_cli_client") as MockBuild,
     ):
-        MockApi.return_value.get_report.return_value = mock_resp
+        MockBuild.return_value.get_report.return_value = mock_resp
         args = _build_parser().parse_args(
             [
                 "report",
@@ -318,10 +377,10 @@ def test_report_run_error_response():
 
     with (
         patch.dict(os.environ, _CREDS),
-        patch("blesta_sdk.cli.commands.report.BlestaRequest") as MockApi,
+        patch("blesta_sdk.cli.commands.report._build_cli_client") as MockBuild,
         pytest.raises(SystemExit),
     ):
-        MockApi.return_value.get_report.return_value = mock_resp
+        MockBuild.return_value.get_report.return_value = mock_resp
         args = _build_parser().parse_args(
             [
                 "report",
@@ -433,12 +492,12 @@ def test_app_main_legacy_mode(capsys):
     mock_resp = _mock_response(data={"id": 1})
     with (
         patch.dict(os.environ, _CREDS),
-        patch("blesta_sdk.cli.app.BlestaRequest") as MockApi,
+        patch("blesta_sdk.cli.app._build_cli_client") as MockBuild,
         patch.object(
             sys, "argv", ["blesta", "--model", "clients", "--method", "getList"]
         ),
     ):
-        MockApi.return_value.submit.return_value = mock_resp
+        MockBuild.return_value.submit.return_value = mock_resp
         main()
 
     out = capsys.readouterr().out
@@ -518,7 +577,7 @@ def test_app_legacy_non200_exits_1(capsys):
     mock_resp.errors.return_value = {"error": "not found"}
     with (
         patch.dict(os.environ, _CREDS),
-        patch("blesta_sdk.cli.app.BlestaRequest") as MockApi,
+        patch("blesta_sdk.cli.app._build_cli_client") as MockBuild,
         patch.object(
             sys,
             "argv",
@@ -526,7 +585,7 @@ def test_app_legacy_non200_exits_1(capsys):
         ),
         pytest.raises(SystemExit) as exc_info,
     ):
-        MockApi.return_value.submit.return_value = mock_resp
+        MockBuild.return_value.submit.return_value = mock_resp
         main()
     assert exc_info.value.code == 1
 
@@ -540,15 +599,15 @@ def test_app_legacy_last_request(capsys):
     last_req = {"url": "https://example.com/api/clients/getList.json", "args": {}}
     with (
         patch.dict(os.environ, _CREDS),
-        patch("blesta_sdk.cli.app.BlestaRequest") as MockApi,
+        patch("blesta_sdk.cli.app._build_cli_client") as MockBuild,
         patch.object(
             sys,
             "argv",
             ["blesta", "--model", "clients", "--method", "getList", "--last-request"],
         ),
     ):
-        MockApi.return_value.submit.return_value = mock_resp
-        MockApi.return_value.get_last_request.return_value = last_req
+        MockBuild.return_value.submit.return_value = mock_resp
+        MockBuild.return_value.get_last_request.return_value = last_req
         main()
 
     out = capsys.readouterr().out
@@ -562,9 +621,9 @@ def test_call_run_duplicate_param(capsys):
     mock_resp = _mock_response(data=[])
     with (
         patch.dict(os.environ, _CREDS),
-        patch("blesta_sdk.cli.commands.call.BlestaRequest") as MockApi,
+        patch("blesta_sdk.cli.commands.call._build_cli_client") as MockBuild,
     ):
-        MockApi.return_value.submit.return_value = mock_resp
+        MockBuild.return_value.submit.return_value = mock_resp
         args = _build_parser().parse_args(
             [
                 "call",
@@ -589,10 +648,10 @@ def test_extract_missing_creds_param():
 
     with (
         patch.dict(os.environ, _CREDS),
-        patch("blesta_sdk.cli.commands.extract.BlestaRequest") as MockApi,
+        patch("blesta_sdk.cli.commands.extract._build_cli_client") as MockBuild,
         pytest.raises(SystemExit),
     ):
-        MockApi.return_value.get_all.return_value = []
+        MockBuild.return_value.get_all.return_value = []
         args = _build_parser().parse_args(
             ["extract", "clients", "getList", "--param", "badparam"]
         )
@@ -606,9 +665,9 @@ def test_extract_run_csv_non_dict(capsys):
     rows = [1, 2, 3]
     with (
         patch.dict(os.environ, _CREDS),
-        patch("blesta_sdk.cli.commands.extract.BlestaRequest") as MockApi,
+        patch("blesta_sdk.cli.commands.extract._build_cli_client") as MockBuild,
     ):
-        MockApi.return_value.get_all.return_value = rows
+        MockBuild.return_value.get_all.return_value = rows
         args = _build_parser().parse_args(
             ["extract", "clients", "getList", "--format", "csv"]
         )
@@ -629,9 +688,9 @@ def test_report_run_with_extra_params(capsys):
 
     with (
         patch.dict(os.environ, _CREDS),
-        patch("blesta_sdk.cli.commands.report.BlestaRequest") as MockApi,
+        patch("blesta_sdk.cli.commands.report._build_cli_client") as MockBuild,
     ):
-        MockApi.return_value.get_report.return_value = mock_resp
+        MockBuild.return_value.get_report.return_value = mock_resp
         args = _build_parser().parse_args(
             [
                 "report",
@@ -646,7 +705,7 @@ def test_report_run_with_extra_params(capsys):
         )
         report.run(args)
 
-    _, kwargs = MockApi.return_value.get_report.call_args
+    _, kwargs = MockBuild.return_value.get_report.call_args
     assert kwargs.get("extra_vars") == {"currency": "USD"} or (
-        MockApi.return_value.get_report.call_args[0][-1] == {"currency": "USD"}
+        MockBuild.return_value.get_report.call_args[0][-1] == {"currency": "USD"}
     )


### PR DESCRIPTION
## Summary

Closes #86.

The same 17-line credential resolution and client construction pattern was duplicated across five CLI surfaces. This PR consolidates it into a single `_build_cli_client()` helper in `cli/formatters.py`, matching the pattern the MCP surface already uses (`mcp/schemas._build_client()`).

## Scope

**Changed:**
- `cli/formatters.py` — adds `_build_cli_client()` with credential reading, auth_method validation, allow_http parsing, and BlestaRequest construction
- `cli/commands/call.py`, `extract.py`, `report.py` — each loses a 17-line credential block; now calls `_build_cli_client()`
- `cli/app.py:_run_legacy()` — uses `_build_cli_client()`; docstring corrected (previously claimed it delegated to `blesta_sdk._cli.cli`, which was wrong)
- `tests/test_cli_commands.py` — patch targets updated; 5 new tests for `_build_cli_client()` directly

**Unchanged:**
- `_cli.py` (legacy module, not touched)
- MCP surface, SDK core, public API, CLI output behaviour

## What was removed (per command file)

```python
# removed from call.py, extract.py, report.py (each):
url = os.getenv("BLESTA_API_URL")
user = os.getenv("BLESTA_API_USER")
key = os.getenv("BLESTA_API_KEY")
if not all([url, user, key]):
    print_error("Missing API credentials. ...")
auth_method = os.getenv("BLESTA_AUTH_METHOD", "basic").strip().lower()
allow_http = os.getenv("BLESTA_ALLOW_HTTP", "").strip().lower() in {"1", "true", "yes", "on"}
api = BlestaRequest(url, user, key, auth_method=auth_method, allow_http=allow_http)
```

Replaced with: `api = _build_cli_client()`

## Verification

```
uv run pytest -v -m "not integration"    934 passed, 1 deselected
uv run ruff check src/ tests/ tools/    All checks passed
uv run black --check src/ tests/ tools/ 58 files unchanged
uv run pytest --cov=blesta_sdk --cov-fail-under=97  97.73% coverage
```

## Compatibility

CLI command behaviour is unchanged. All public imports, MCP surface, and package extras are unaffected. The `_cli.py` legacy module is unchanged.

## Follow-up

- #87 — Simplify module boundaries (audit finding: no changes needed)
- #88 — Fix docs drift
- #89 — Final QA
