### PR TITLE
Verify documentation matches code and commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **CLI credential resolution centralised** — `_build_cli_client()` helper added to
+  `blesta_sdk.cli.formatters`; all four CLI surfaces (`call`, `extract`, `report`,
+  `app._run_legacy`) now use it instead of duplicating the same 17-line credential/client
+  block. No behaviour change.
+
+### Fixed
+
+- **`cli/app.py` docstring** — `_run_legacy()` docstring incorrectly claimed it delegated
+  to `blesta_sdk._cli.cli`. It has always been an independent implementation; the docstring
+  is now accurate.
+- **`CLI_USAGE.md`** — `BLESTA_ALLOW_HTTP` was missing from the env-var reference table.
+  Added with default, accepted values, and a note that HTTPS is enforced by default.
+
 ## [0.8.1] - 2026-05-27
 
 ### Fixed

--- a/CLI_USAGE.md
+++ b/CLI_USAGE.md
@@ -200,5 +200,6 @@ blesta extract clients getList --format jsonl | jq '.id'
 | `BLESTA_API_USER` | Yes | — | API username |
 | `BLESTA_API_KEY` | Yes | — | API key |
 | `BLESTA_AUTH_METHOD` | No | `basic` | `basic` or `header` |
+| `BLESTA_ALLOW_HTTP` | No | unset | Set to `1`, `true`, `yes`, or `on` to permit `http://` base URLs (local/dev only; HTTPS is enforced by default) |
 
 See [`SDK_USAGE.md`](SDK_USAGE.md) for the full programmatic API reference.


### PR DESCRIPTION
## Summary

Closes #88.

Two confirmed documentation gaps from the audit (#84):

1. **`BLESTA_ALLOW_HTTP` missing from `CLI_USAGE.md`** — the env-var reference table listed only 4 variables; `BLESTA_ALLOW_HTTP` was absent. It was already implemented in `_build_cli_client()` and documented in `MCP_USAGE.md` and `README.md`.
2. **`CHANGELOG.md [Unreleased]`** — updated with the code quality cleanup changes from the cleanup sprint.

## Docs verified

| Doc | Result |
|---|---|
| `README.md` | CLI subcommand syntax, import examples, API class signatures — all match current code |
| `SDK_USAGE.md` | All import paths verified importable; MCP handler names verified present |
| `CLI_USAGE.md` | Added `BLESTA_ALLOW_HTTP`; all other env vars and commands verified |
| `MCP_USAGE.md` | 10 tools, 7 resources, 5 prompts — all match `TOOL_REGISTRY`, `RESOURCE_REGISTRY`, `PROMPT_REGISTRY` |
| `CHANGELOG.md` | `[Unreleased]` updated; past versions accurate |
| `pyproject.toml` | Version `0.8.1`, extras (`cli`, `async`, `mcp`, `data`), scripts (`blesta`, `blesta-mcp`) — all correct |

## Verification

```
uv run pytest -v -m "not integration"    934 passed, 1 deselected
uv run ruff check src/ tests/ tools/    All checks passed
uv run black --check src/ tests/ tools/ 58 files unchanged
uv run blesta --help                    shows all 4 subcommands
uv run python -c "import blesta_sdk; print(blesta_sdk.__version__)"  0.8.1
```

## Compatibility

No source code changed. All public imports, CLI commands, MCP tools/resources, and package extras are unaffected.
