### PR TITLE
release 0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.2] - 2026-05-27
+
 ### Changed
 
 - **CLI credential resolution centralised** — `_build_cli_client()` helper added to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blesta_sdk"
-version = "0.8.1"
+version = "0.8.2"
 description = "Python SDK and CLI for the Blesta billing platform REST API"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## v0.8.2

Patch release completing the post-v0.8.0 code quality sprint.

### Changed

- **CLI credential resolution centralised** — `_build_cli_client()` helper added to `blesta_sdk.cli.formatters`; `call`, `extract`, `report`, and `app._run_legacy` all use it instead of each duplicating the same 17-line credential/client construction block. No behaviour change for callers.

### Fixed

- **`cli/app.py:_run_legacy()` docstring** — incorrectly said it delegated to `blesta_sdk._cli.cli`; updated to accurately describe the implementation.
- **`CLI_USAGE.md`** — `BLESTA_ALLOW_HTTP` was missing from the env-var reference table. Added with accepted values and a note that HTTPS is enforced by default.

### Verified

- 934 tests passing, 97.86% coverage
- ruff clean, black clean
- `dist/blesta_sdk-0.8.2` builds and passes twine check
- Wheel smoke-test passes in isolated install
