### PR TITLE
Verify v0.8.2 docs match code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`blesta call` exit code** — the `call` subcommand now exits with code 1 on non-200
+  HTTP responses, matching the documented behaviour in `CLI_USAGE.md` and `README.md`.
+  Previously only the legacy `--model/--method` mode exited non-zero on HTTP errors.
+
+### Changed
+
+- **CLAUDE.md project structure** — updated all module paths from legacy flat layout
+  (`_client.py`, `_cli.py`, `_discovery.py`, etc.) to the current namespaced layout
+  (`core/client.py`, `cli/app.py`, `discovery/registry.py`, etc.). Entry-point script
+  is correctly shown as `blesta_sdk.cli.app:main`.
+- **CLAUDE.md architecture notes** — removed references to non-existent `response.ok`
+  property; use `response.errors()` and `raise_on_error=True` instead.
+- **README.md and SDK_USAGE.md** — DataFrame conversion section now mentions
+  `pip install "blesta_sdk[data]"` as the preferred install path for pandas support.
+- **SDK_USAGE.md** — `call()` schema-aware description corrected: ambiguous method names
+  raise `ValueError`, not silently default to POST.
+
 ## [0.8.2] - 2026-05-28
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,33 +35,36 @@ uv run python tools/extract_plugin_schema.py                    # Re-extract plu
 ## Project Structure
 
 - `src/blesta_sdk/__init__.py` — public API exports (`__all__`), lazy import for `AsyncBlestaRequest`
-- `src/blesta_sdk/_client.py` — `BlestaRequest`: sync HTTP client (GET/POST/PUT/DELETE, `submit()`, `call()`, `call_all()`, `count_for()`, pagination, reports, batch extraction)
-- `src/blesta_sdk/_async_client.py` — `AsyncBlestaRequest`: async HTTP client (mirrors sync API, adds `get_all_fast()` and `get_report_series_concurrent()`)
-- `src/blesta_sdk/_response.py` — `BlestaResponse`: response parsing, CSV/JSON detection, error extraction, `raise_for_status()`, DataFrame conversion
-- `src/blesta_sdk/_pagination.py` — `PaginationState`: shared pagination logic with stuck-page and alternating-loop cycle detection; used by both sync and async clients
-- `src/blesta_sdk/_redaction.py` — `redact_args()`: shared sensitive-key scrubber used by both clients for `get_last_request()` output
-- `src/blesta_sdk/_discovery.py` — `BlestaDiscovery` and `MethodSpec`: schema-driven API introspection (lazy-loaded)
-- `src/blesta_sdk/_exceptions.py` — typed exception hierarchy: `BlestaError`, `BlestaConnectionError`, `BlestaAPIError`, `BlestaAuthError`, `BlestaRateLimitError` (`.retry_after`), `BlestaServerError`, `PaginationError`
-- `src/blesta_sdk/_env_config.py` — `BlestaEnvConfig`: environment-keyed credential resolution (`dev`/`stage`/`live`) with no cross-env fallback
-- `src/blesta_sdk/_validation.py` — shared URL segment validation used by both clients
-- `src/blesta_sdk/_dateutil.py` — `_month_boundaries()` for time-series report date ranges
-- `src/blesta_sdk/_cli.py` — CLI entry point (registered as `blesta` in pyproject.toml)
-- `src/blesta_sdk/schemas/` — **canonical** bundled JSON schemas (core: 63 models, plugin: 8 models) used by `BlestaDiscovery`. Do not edit the deprecated root-level `schemas/` copies.
+- `src/blesta_sdk/core/client.py` — `BlestaRequest`: sync HTTP client (GET/POST/PUT/DELETE, `submit()`, `call()`, `call_all()`, `count_for()`, pagination, reports, batch extraction)
+- `src/blesta_sdk/core/async_client.py` — `AsyncBlestaRequest`: async HTTP client (mirrors sync API, adds `get_all_fast()` and `get_report_series_concurrent()`)
+- `src/blesta_sdk/core/response.py` — `BlestaResponse`: response parsing, CSV/JSON detection, error extraction, `raise_for_status()`, DataFrame conversion
+- `src/blesta_sdk/core/pagination.py` — `PaginationState`: shared pagination logic with stuck-page and alternating-loop cycle detection; used by both sync and async clients
+- `src/blesta_sdk/core/redaction.py` — `redact_args()`: shared sensitive-key scrubber used by both clients for `get_last_request()` output
+- `src/blesta_sdk/discovery/registry.py` — `BlestaDiscovery` and `MethodSpec`: schema-driven API introspection (lazy-loaded)
+- `src/blesta_sdk/core/errors.py` — typed exception hierarchy: `BlestaError`, `BlestaConnectionError`, `BlestaAPIError`, `BlestaAuthError`, `BlestaRateLimitError` (`.retry_after`), `BlestaServerError`, `PaginationError`
+- `src/blesta_sdk/core/config.py` — `BlestaEnvConfig`: environment-keyed credential resolution (`dev`/`stage`/`live`) with no cross-env fallback
+- `src/blesta_sdk/core/validation.py` — shared URL segment validation used by both clients
+- `src/blesta_sdk/core/dateutil.py` — `_month_boundaries()` for time-series report date ranges
+- `src/blesta_sdk/cli/app.py` — CLI entry point (registered as `blesta` in pyproject.toml via `blesta_sdk.cli.app:main`)
+- `src/blesta_sdk/cli/commands/` — CLI subcommands: `call.py`, `extract.py`, `report.py`, `discover.py`
+- `src/blesta_sdk/mcp/server.py` — MCP server entry point (registered as `blesta-mcp` via `blesta_sdk.mcp.server:main`)
+- `src/blesta_sdk/mcp/tools.py`, `resources.py`, `prompts.py` — MCP tool/resource/prompt registrations
+- `src/blesta_sdk/schemas/` — **canonical** bundled JSON schemas (core: 63 models, plugin: 8 models) used by `BlestaDiscovery`
 - `tools/` — schema extraction utilities (`extract_schema.py`, `extract_plugin_schema.py`, `_classify.py`); write to `src/blesta_sdk/schemas/` by default
 - `tests/` — unit tests (mocked) + one live integration test (`test_credentials`)
 - `benchmarks/` — performance benchmarks (pytest-benchmark, not collected in CI)
 
 ## Architecture: Cross-Cutting Patterns
 
-**All requests return `BlestaResponse`** — never raw dicts or `False`. Network errors produce `status_code=0`. Callers check `response.ok`, `response.data`, or call `response.raise_for_status()` to get typed exceptions.
+**All requests return `BlestaResponse`** — never raw dicts or `False`. Network errors produce `status_code=0`. Callers check `response.data`, `response.errors()`, or call `response.raise_for_status()` to get typed exceptions.
 
-**HTTP 200 ≠ success** — Blesta returns HTTP 200 with an `errors` key for validation failures. Always check `response.errors` or `response.ok`, not just the status code.
+**HTTP 200 ≠ success** — Blesta returns HTTP 200 with an `errors` key for validation failures. Always check `response.errors()` or use `raise_on_error=True`, not just the status code.
 
-**Pagination** is handled by `PaginationState` (shared between `_client.py` and `_async_client.py`). It detects stuck pages (3 consecutive identical pages) and alternating loops, raising `PaginationError` rather than looping forever.
+**Pagination** is handled by `PaginationState` (shared between `core/client.py` and `core/async_client.py`). It detects stuck pages (3 consecutive identical pages) and alternating loops, raising `PaginationError` rather than looping forever.
 
 **Retry logic** in both clients respects the `Retry-After` response header on 429s. If the header is present and non-zero, the client sleeps for that many seconds instead of using exponential backoff.
 
-**`get_last_request()`** returns a redacted copy of the last request's args (sensitive keys replaced with `"***"` by `redact_args()` in `_redaction.py`). The actual HTTP request is never modified. In async context, this is per-asyncio-task via `ContextVar`.
+**`get_last_request()`** returns a redacted copy of the last request's args (sensitive keys replaced with `"***"` by `redact_args()` in `core/redaction.py`). The actual HTTP request is never modified. In async context, this is per-asyncio-task via `ContextVar`.
 
 **Schema-aware calls** (`call()`, `call_all()`, `count_for()`) use bundled schemas to infer the correct HTTP method from the model/method name, falling back to prefix heuristics (`get*` → GET, `add*`/`create*` → POST, etc.).
 
@@ -110,7 +113,7 @@ BLESTA_API_USER=your_api_user
 BLESTA_API_KEY=your_api_key
 ```
 
-The `--last-request` CLI flag returns a redacted args dict (sensitive values shown as `"***"`). The programmatic API takes credentials as constructor arguments directly.
+The `--last-request` flag (legacy mode only) returns a redacted args dict (sensitive values shown as `"***"`). The programmatic API takes credentials as constructor arguments directly.
 
 ## CI/CD
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ For async support:
 pip install blesta_sdk[async]
 ```
 
+For pandas/DataFrame support:
+
+```bash
+pip install "blesta_sdk[data]"
+```
+
 For the MCP server (Python 3.10+):
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ for period, response in api.get_report_series_pages("tax_liability", "2024-01", 
 
 ### DataFrame Conversion
 
-Requires pandas (`pip install pandas` or `uv add pandas`).
+Requires pandas. Install with `pip install "blesta_sdk[data]"` or install pandas directly (`pip install pandas`).
 
 ```python
 response = api.get_report("package_revenue", "2025-01-01", "2025-01-31")

--- a/SDK_USAGE.md
+++ b/SDK_USAGE.md
@@ -81,7 +81,7 @@ response = api.submit("clients", "create", {"firstname": "John"}, action="POST")
 
 ### Schema-Aware Calls
 
-`call()` infers the HTTP method from the bundled API schema. If a method is not in the schema, the SDK infers the verb from the method name (e.g. `get*` -> GET, `create*` -> POST, `edit*` -> PUT, `delete*` -> DELETE). If still ambiguous, defaults to POST with a warning.
+`call()` infers the HTTP method from the bundled API schema. If a method is not in the schema, the SDK infers the verb from the method name (e.g. `get*` -> GET, `create*` -> POST, `edit*` -> PUT, `delete*` -> DELETE). If the HTTP method still cannot be determined, `ValueError` is raised — pass `action=` explicitly to avoid this.
 
 ```python
 response = api.call("clients", "getList")   # infers GET
@@ -227,7 +227,7 @@ for period, response in api.get_report_series_pages("tax_liability", "2025-01", 
 
 ## DataFrame Conversion
 
-Requires `pandas` (`pip install pandas`).
+Requires pandas. Install with `pip install "blesta_sdk[data]"` or install pandas directly (`pip install pandas`).
 
 ```python
 # CSV response

--- a/src/blesta_sdk/cli/commands/call.py
+++ b/src/blesta_sdk/cli/commands/call.py
@@ -70,4 +70,7 @@ def run(args: argparse.Namespace) -> None:
     if response.status_code == 200:
         print_json(response.data)
     else:
-        print_json(response.errors())
+        print_error(
+            f"API error: HTTP {response.status_code}",
+            exit_code=1,
+        )

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -201,6 +201,7 @@ def test_call_run_non200(capsys):
     with (
         patch.dict(os.environ, _CREDS),
         patch("blesta_sdk.cli.commands.call._build_cli_client") as MockBuild,
+        pytest.raises(SystemExit) as exc_info,
     ):
         MockBuild.return_value.submit.return_value = mock_resp
         args = _build_parser().parse_args(
@@ -208,6 +209,7 @@ def test_call_run_non200(capsys):
         )
         call.run(args)
 
+    assert exc_info.value.code == 1
     out = capsys.readouterr().out
     data = json.loads(out)
     assert "error" in data


### PR DESCRIPTION
## Summary

Verifies the v0.8.2 docs against the current SDK, CLI, and MCP implementation and fixes confirmed drift.

Closes #95

## Changes

- **Fix**: `blesta call` subcommand now exits with code 1 on non-200 HTTP responses. Previously only the legacy `--model/--method` mode exited non-zero; the `call` subcommand printed errors but returned exit 0.
- **CLAUDE.md**: Updated all module paths from the legacy flat layout (`_client.py`, `_cli.py`, `_discovery.py`, etc.) to the current namespaced layout (`core/client.py`, `cli/app.py`, `discovery/registry.py`). Fixed incorrect `response.ok` property references (property does not exist — use `response.errors()`). Updated pagination and redaction cross-references.
- **README.md**: DataFrame conversion section now references `pip install "blesta_sdk[data]"` for pandas.
- **SDK_USAGE.md**: DataFrame section updated with `[data]` extra. `call()` schema-aware description corrected — ambiguous method names raise `ValueError`, not silently default to POST.
- **CHANGELOG.md**: Added [Unreleased] entry for all changes.
- **Tests**: Updated `test_call_run_non200` to assert `SystemExit(1)` is raised.

## Verified

- pyproject.toml scripts and extras match docs (blesta_sdk.cli.app:main, blesta_sdk.mcp.server:main)
- README install/API examples
- SDK_USAGE examples and call() behavior
- CLI_USAGE commands and env vars — all documented commands/flags match parser
- MCP_USAGE: tools (10), resources (7), prompts (5) all match registries; .env autoload verified in server.py
- retry/error/http safety docs verified accurate

## Tests

All tests pass:
- `uv run pytest -v -m "not integration"` — 934 passed
- `uv run pytest --cov=blesta_sdk --cov-fail-under=97 -m "not integration"` — 97.86% coverage
- `uv run ruff check src/ tests/ tools/` — clean
- `uv run black --check src/ tests/ tools/` — clean
- `uv build` — succeeded
- `uvx twine check dist/blesta_sdk-0.8.2*` — PASSED

## Compatibility

- Public imports unchanged
- CLI command names unchanged
- MCP tool/resource/prompt names unchanged
- No retry or HTTP safety behavior relaxed
- Exit code behavior for `blesta call` is now consistent with documented spec (breaking only for callers silently relying on exit 0 after HTTP errors)